### PR TITLE
Add default DiagnosticSeverity.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,12 @@ pub enum DiagnosticSeverity {
     Hint = 4,
 }
 
+impl Default for DiagnosticSeverity {
+    fn default() -> Self {
+        DiagnosticSeverity::Hint
+    }
+}
+
 /// Represents a related message and source code location for a diagnostic. This
 /// should be used to point to code locations that cause or related to a
 /// diagnostics, e.g when duplicating a symbol in a scope.


### PR DESCRIPTION
The motivation for adding this is to ease working with `Option<DiagnosticSeverity>`.

To be frank, I'm sure what the default value should be.