### PR TITLE
lib.rs: Update SignatureHelp parameter types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2487,11 +2487,11 @@ pub struct SignatureHelp {
 
     /// The active signature.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_signature: Option<u64>,
+    pub active_signature: Option<i64>,
 
     /// The active parameter of the active signature.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_parameter: Option<u64>,
+    pub active_parameter: Option<i64>,
 }
 
 /// Represents the signature of something callable. A signature


### PR DESCRIPTION
According to LSP spec, SignatureHelp::active_parameter and
SignatureHelp::active_signature have type `number` which can have negative
values as well.

Change the type of parameters in the struct from u64 to i64 to allow
de-serializing from servers that set the value of these parameters to -1 to
indicate value that is ignored.

Partially fixes issue #84.