### PR TITLE
Adjust CodeActionResponse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2835,11 +2835,13 @@ pub struct CodeActionParams {
 }
 
 /// response for CodeActionRequest
-#[derive(Debug, Clone, Deserialize, Serialize)]
+pub type CodeActionResponse = Vec<CodeActionOrCommand>;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum CodeActionResponse {
-    Commands(Vec<Command>),
-    Actions(Vec<CodeAction>),
+pub enum CodeActionOrCommand {
+    Command(Command),
+    CodeAction(CodeAction),
 }
 
 /**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3550,4 +3550,23 @@ mod tests {
             r#"["create","rename","delete"]"#,
         );
     }
+
+    #[test]
+    fn test_code_action_response() {
+        test_serialization(
+            &vec![CodeActionOrCommand::Command(Command {
+                title: "title".to_string(),
+                command: "command".to_string(),
+                arguments: None,
+            }),
+            CodeActionOrCommand::CodeAction(CodeAction {
+                title: "title".to_string(),
+                kind: Some(code_action_kind::QUICKFIX.to_owned()),
+                command: None,
+                diagnostics: None,
+                edit: None,
+            })],
+            r#"[{"title":"title","command":"command"},{"title":"title","kind":"quickfix"}]"#,
+        )
+    }
 }


### PR DESCRIPTION
Looking at [`textDocument/codeAction`](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction) it seems to be returning heterogeneous array `(Command | CodeAction)[] | null` rather than `Command[] | CodeAction[] | null` so I adjusted that accordingly.

Discovered this while working on https://github.com/rust-lang/rls-vscode/issues/609 - right now RLS sends only `Vec<Command>` but to fix the issue we also need send some `CodeAction`s as well, hence why we need the heterogenous array.

r? @Marwes 