### PR TITLE
Update proposed progress support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1328,10 +1328,10 @@ pub struct TextDocumentClientCapabilities {
 #[serde(rename_all = "camelCase")]
 pub struct WindowClientCapabilities {
     /**
-     * Whether `window/progress` server notifications are supported.
+     * Whether client supports create a work done progress UI from the server side.
      */
     #[cfg(feature = "proposed")]
-    pub progress: Option<bool>,
+    pub work_done_progress: Option<bool>,
 }
 
 /**
@@ -3307,18 +3307,61 @@ pub struct MarkupContent {
 }
 
 #[cfg(feature = "proposed")]
+pub type ProgressToken = NumberOrString;
+
+#[cfg(feature = "proposed")]
 /// The progress notification is sent from the server to the client to ask
 /// the client to indicate progress.
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct ProgressParams {
-    /// A unique identifier to associate multiple progress notifications
-    /// with the same progress.
-    pub id: String,
+    /// The progress token provided by the client.
+    pub token: ProgressToken,
 
+    /// The progress data.
+    pub value: ProgressParamsValue,
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum ProgressParamsValue {
+    WorkDone(WorkDoneProgress)
+}
+
+#[cfg(feature = "proposed")]
+/// The `window/workDoneProgress/create` request is sent from the server 
+/// to the clientto ask the client to create a work done progress.
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkDoneProgressCreateParams {
+    /// The token to be used to report progress.
+    pub token: ProgressToken,
+}
+
+#[cfg(feature = "proposed")]
+/// The `window/workDoneProgress/cancel` is sent from the client to the server 
+/// to indicate that the user has pressed cancel on a server initiated work done progress.
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkDoneProgressCancelParams {
+    /// The token to be used to report progress.
+    pub token: ProgressToken,
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkDoneProgressBegin {
     /// Mandatory title of the progress operation. Used to briefly inform
     /// about the kind of operation being performed.
     /// Examples: "Indexing" or "Linking dependencies".
     pub title: String,
+
+    /// Controls if a cancel button should show to allow the user to cancel the
+	/// long running operation. Clients that don't support cancellation are allowed
+	/// to ignore the setting.
+    pub cancellable: Option<bool>,
 
     /// Optional, more detailed associated progress message. Contains
     /// complementary information to the `title`.
@@ -3329,10 +3372,46 @@ pub struct ProgressParams {
     /// Optional progress percentage to display (value 100 is considered 100%).
     /// If unset, the previous progress percentage (if any) is still valid.
     pub percentage: Option<f64>,
+}
 
-    /// Set to true on the final progress update.
-    /// No more progress notifications with the same ID should be sent.
-    pub done: Option<bool>,
+#[cfg(feature = "proposed")]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkDoneProgressReport {
+    /// Controls if a cancel button should show to allow the user to cancel the
+	/// long running operation. Clients that don't support cancellation are allowed
+	/// to ignore the setting.
+    pub cancellable: Option<bool>,
+
+    /// Optional, more detailed associated progress message. Contains
+    /// complementary information to the `title`.
+    /// Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".
+    /// If unset, the previous progress message (if any) is still valid.
+    pub message: Option<String>,
+
+    /// Optional progress percentage to display (value 100 is considered 100%).
+    /// If unset, the previous progress percentage (if any) is still valid.
+    pub percentage: Option<f64>,
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkDoneProgressDone {
+    /// Optional, more detailed associated progress message. Contains
+    /// complementary information to the `title`.
+    /// Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".
+    /// If unset, the previous progress message (if any) is still valid.
+    pub message: Option<String>,
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum WorkDoneProgress {
+    Begin(WorkDoneProgressBegin),
+    Report(WorkDoneProgressReport),
+    Done(WorkDoneProgressDone),
 }
 
 #[cfg(test)]

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -61,8 +61,13 @@ macro_rules! lsp_notification {
     };
 
     // Requires #[cfg(feature = "proposed")]
-    ("window/progress") => {
+    ("$/progress") => {
         $crate::notification::Progress
+    };
+
+    // Requires #[cfg(feature = "proposed")]
+    ("window/workDoneProgress/cancel") => {
+        $crate::notification::WorkDoneProgressCancel
     };
 }
 
@@ -266,7 +271,19 @@ pub enum Progress {}
 #[cfg(feature = "proposed")]
 impl Notification for Progress {
     type Params = ProgressParams;
-    const METHOD: &'static str = "window/progress";
+    const METHOD: &'static str = "$/progress";
+}
+
+#[cfg(feature = "proposed")]
+/// The `window/workDoneProgress/cancel` is sent from the client to the server 
+/// to indicate that the user has pressed cancel on a server initiated work done progress.
+#[derive(Debug)]
+pub enum WorkDoneProgressCancel {}
+
+#[cfg(feature = "proposed")]
+impl Notification for WorkDoneProgressCancel {
+    type Params = WorkDoneProgressCancelParams;
+    const METHOD: &'static str = "window/workDoneProgress/cancel";
 }
 
 #[cfg(test)]
@@ -307,8 +324,12 @@ mod test {
         check_macro!("workspace/didChangeConfiguration");
         check_macro!("workspace/didChangeWatchedFiles");
         check_macro!("workspace/didChangeWorkspaceFolders");
+    }
 
-        #[cfg(feature = "proposed")]
-        check_macro!("window/progress");
+    #[test]
+    #[cfg(feature = "proposed")]
+    fn check_proposed_macro_definitions() {
+        check_macro!("$/progress");
+        check_macro!("window/workDoneProgress/cancel");
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -117,6 +117,11 @@ macro_rules! lsp_request {
     ("workspace/configuration") => {
         $crate::request::WorkspaceConfiguration
     };
+
+    // Requires #[cfg(feature = "proposed")]
+    ("window/workDoneProgress/create") => {
+        $crate::request::WorkDoneProgressCreate
+    };
 }
 
 /**
@@ -581,6 +586,19 @@ impl Request for WorkspaceFoldersRequest {
     const METHOD: &'static str = "workspace/workspaceFolders";
 }
 
+/// The `window/workDoneProgress/create` request is sent from the server 
+/// to the clientto ask the client to create a work done progress.
+#[cfg(feature = "proposed")]
+#[derive(Debug)]
+pub enum WorkDoneProgressCreate {}
+
+#[cfg(feature = "proposed")]
+impl Request for WorkDoneProgressCreate {
+    type Params = WorkDoneProgressCreateParams;
+    type Result = ();
+    const METHOD: &'static str = "window/workDoneProgress/create";
+}
+
 ///The selection range request is sent from the client to the server to return
 ///suggested selection ranges at given positions. A selection range is a range
 ///around the cursor position which the user might be interested in selecting.
@@ -662,5 +680,6 @@ mod test {
     #[cfg(feature = "proposed")]
     fn check_proposed_macro_definitions() {
         check_macro!("textDocument/selectionRange");
+        check_macro!("window/workDoneProgress/create");
     }
 }


### PR DESCRIPTION
The proposed progress support of the protocol was updated, see https://github.com/microsoft/language-server-protocol/issues/786 for details. It is already implemented in the https://github.com/microsoft/vscode-languageserver-node/commit/cd6dcf0e1cf0f8e3b14b78b3322857f6f636ee7d library.

This PR adds all types for the ["Work Done"](https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.progress.proposed.md#reporting-server-task-progress) part of the spec.