### PR TITLE
Remove references token modifier.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3877,7 +3877,6 @@ impl SemanticTokenModifier {
     pub const DOCUMENTATION: SemanticTokenModifier = SemanticTokenModifier::new("documentation");
     pub const DECLARATION: SemanticTokenModifier = SemanticTokenModifier::new("declaration");
     pub const DEFINITION: SemanticTokenModifier = SemanticTokenModifier::new("definition");
-    pub const REFERENCE: SemanticTokenModifier = SemanticTokenModifier::new("reference");
     pub const STATIC: SemanticTokenModifier = SemanticTokenModifier::new("static");
     pub const ABSTRACT: SemanticTokenModifier = SemanticTokenModifier::new("abstract");
     pub const DEPRECATED: SemanticTokenModifier = SemanticTokenModifier::new("deprecated");


### PR DESCRIPTION
https://github.com/microsoft/vscode-languageserver-node/commit/b382b6ac418afd21805c6173f71559edf97dba8d

We have 'declaration', everything else is a 'reference'