### PR TITLE
Redefine textDocument/willSaveWaitUntil as a request

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -312,7 +312,6 @@ mod test {
         check_macro!("textDocument/didOpen");
         check_macro!("textDocument/didChange");
         check_macro!("textDocument/willSave");
-        check_macro!("textDocument/willSaveWaitUntil");
         check_macro!("textDocument/didSave");
         check_macro!("textDocument/didClose");
         check_macro!("textDocument/publishDiagnostics");

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -40,9 +40,6 @@ macro_rules! lsp_notification {
     ("textDocument/willSave") => {
         $crate::notification::WillSaveTextDocument
     };
-    ("textDocument/willSaveWaitUntil") => {
-        $crate::notification::WillSaveWaitUntil
-    };
     ("textDocument/didSave") => {
         $crate::notification::DidSaveTextDocument
     };
@@ -188,19 +185,6 @@ pub enum WillSaveTextDocument {}
 impl Notification for WillSaveTextDocument {
     type Params = WillSaveTextDocumentParams;
     const METHOD: &'static str = "textDocument/willSave";
-}
-
-/// The document will save request is sent from the client to the server before the document is
-/// actually saved. The request can return an array of TextEdits which will be applied to the text
-/// document before it is saved. Please note that clients might drop results if computing the text
-/// edits took too long or if a server constantly fails on this request. This is done to keep the
-/// save fast and reliable.
-#[derive(Debug)]
-pub enum WillSaveWaitUntil {}
-
-impl Notification for WillSaveWaitUntil {
-    type Params = WillSaveTextDocumentParams;
-    const METHOD: &'static str = "textDocument/willSaveWaitUntil";
 }
 
 /**

--- a/src/request.rs
+++ b/src/request.rs
@@ -33,6 +33,10 @@ macro_rules! lsp_request {
         $crate::request::ExecuteCommand
     };
 
+    ("textDocument/willSaveWaitUntil") => {
+        $crate::request::WillSaveWaitUntil
+    };
+
     ("textDocument/completion") => {
         $crate::request::Completion
     };
@@ -409,6 +413,20 @@ impl Request for ExecuteCommand {
     type Params = ExecuteCommandParams;
     type Result = Option<Value>;
     const METHOD: &'static str = "workspace/executeCommand";
+}
+
+/// The document will save request is sent from the client to the server before the document is
+/// actually saved. The request can return an array of TextEdits which will be applied to the text
+/// document before it is saved. Please note that clients might drop results if computing the text
+/// edits took too long or if a server constantly fails on this request. This is done to keep the
+/// save fast and reliable.
+#[derive(Debug)]
+pub enum WillSaveWaitUntil {}
+
+impl Request for WillSaveWaitUntil {
+    type Params = WillSaveTextDocumentParams;
+    type Result = Option<Vec<TextEdit>>;
+    const METHOD: &'static str = "textDocument/willSaveWaitUntil";
 }
 
 /// The workspace/applyEdit request is sent from the server to the client to modify resource on the

--- a/src/request.rs
+++ b/src/request.rs
@@ -745,6 +745,7 @@ mod test {
         check_macro!("client/unregisterCapability");
         check_macro!("workspace/symbol");
         check_macro!("workspace/executeCommand");
+        check_macro!("textDocument/willSaveWaitUntil");
         check_macro!("textDocument/completion");
         check_macro!("completionItem/resolve");
         check_macro!("textDocument/hover");


### PR DESCRIPTION
### Changed

* Updated the `lsp_notification!()` and `lsp_request!()` macros to match the new status of `WaitSaveWaitUntil`.

### Fixed

* Redefine `textDocument/willSaveWaitUntil` as a request.

Fixes #142.

