### PR TITLE
Add #![forbid(unsafe_code)] crate attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ able to parse any URI, such as `urn:isbn:0451450523`.
 
 */
 #![allow(non_upper_case_globals)]
+#![forbid(unsafe_code)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
Pretty sure that unsafe code is never going to be a problem with this crate, but it can help a bit when inspecting the `cargo-geiger` output of a dependency tree, and having it in the `lib.rs` gives off a warm, fuzzy feeling.