### PR TITLE
feat: Add DeserializeOwned + Serialize bounds on request/notifications

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+use serde::{de::DeserializeOwned, Serialize};
+
 pub trait Notification {
-    type Params;
+    type Params: DeserializeOwned + Serialize;
     const METHOD: &'static str;
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,8 +1,10 @@
 use super::*;
 
+use serde::{de::DeserializeOwned, Serialize};
+
 pub trait Request {
-    type Params;
-    type Result;
+    type Params: DeserializeOwned + Serialize;
+    type Result: DeserializeOwned + Serialize;
     const METHOD: &'static str;
 }
 


### PR DESCRIPTION
This will always be true since otherwise there would be no way to
send/receive the params or result.

Fixes #140