### PR TITLE
Use DocumentLinkCapabilities in TextDocumentClientCapabilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1393,7 +1393,7 @@ pub struct TextDocumentClientCapabilities {
      * Capabilities specific to the `textDocument/documentLink`
      */
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document_link: Option<GenericCapability>,
+    pub document_link: Option<DocumentLinkCapabilities>,
 
     /**
      * Capabilities specific to the `textDocument/documentColor` and the


### PR DESCRIPTION
### Fixed

* Use `DocumentLinkCapabilities` in `TextDocumentClientCapabilities`.

The previous version of the code used `GenericCapability` instead, and the `DocumentLinkCapabilities` type was defined but unused. This should fix support for `textDocument/documentLink` tooltip support for LSP version 3.15.0.