### PR TITLE
Fix SelectionRangeRequest::Result type

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -652,7 +652,7 @@ pub enum SelectionRangeRequest {}
 
 impl Request for SelectionRangeRequest {
     type Params = SelectionRangeParams;
-    type Result = Vec<SelectionRange>;
+    type Result = Option<Vec<SelectionRange>>;
     const METHOD: &'static str = "textDocument/selectionRange";
 }
 


### PR DESCRIPTION
### Fixed

* Change `SelectionRangeRequest::Result` associated type from `Vec<SelectionRange>` to `Option<Vec<SelectionRange>>`.

According to the [specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_selectionRange), the `textDocument/selectionRange` response result type is `SelectionRange[] | null`.

This means that the correct result type should be `Option<Vec<SelectionRange>>`.