### PR TITLE
Skip serializing color_provider if None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,6 +1269,7 @@ pub struct TextDocumentClientCapabilities {
 
     /// Capabilities specific to the `textDocument/documentColor` and the
     /// `textDocument/colorPresentation` request.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color_provider: Option<GenericCapability>,
 
     /// Capabilities specific to the `textDocument/rename`


### PR DESCRIPTION
Noticed that `color_provider` is missing the `skip_serializing_if` attribute. As per [the specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize), this value should either not be sent or sent with a non-null value.

This is causing issues in LanguageClient-neovim for some specific servers, see: https://github.com/autozimu/LanguageClient-neovim/issues/940