### PR TITLE
Minimum serde_json required to build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 [dependencies]
 bitflags = "1.0.1"
 serde = { version = "1.0.34", features = ["derive"] }
-serde_json = "1.0.0"
+serde_json = "1.0.50"
 serde_repr = "0.1"
 url = {version = "2.0.0", features = ["serde"]}
 base64 = "0.12.0"


### PR DESCRIPTION
`json::Value` requires `Eq` which wasn't implemented until serde_json 1.0.50