### PR TITLE
Add missing TextDocumentSaveRegistrationOptions struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1980,6 +1980,17 @@ pub struct DidSaveTextDocumentParams {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextDocumentSaveRegistrationOptions {
+    /// The client is supposed to include the content on save.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_text: Option<bool>,
+
+    #[serde(flatten)]
+    pub text_document_registration_options: TextDocumentRegistrationOptions,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct DidChangeWatchedFilesParams {
     /// The actual file events.
     pub changes: Vec<FileEvent>,


### PR DESCRIPTION
The `TextDocumentSaveRegistrationOptions` interface is described [in the `textDocument/didSave` section of the LSP spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didSave). These options are necessary when registering for the `textDocument/didSave` request. It seems to have existed since v3.0, judging by the GitHub Pages history for the official site.

Found this omission while investigating https://github.com/ebkalderon/tower-lsp/issues/190.