### PR TITLE
Add missing optional text field in DidSaveTextDocumentParams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1667,6 +1667,10 @@ pub struct DidCloseTextDocumentParams {
 pub struct DidSaveTextDocumentParams {
     /// The document that was saved.
     pub text_document: TextDocumentIdentifier,
+    /// Optional the content when saved. Depends on the includeText value
+    /// when the save notification was requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
```typescript
interface DidSaveTextDocumentParams {
	/**
	 * The document that was saved.
	 */
	textDocument: TextDocumentIdentifier;

	/**
	 * Optional the content when saved. Depends on the includeText value
	 * when the save notification was requested.
	 */
	text?: string;
}
```

https://microsoft.github.io/language-server-protocol/specification#textDocument_didSave