### PR TITLE
Fix the type of `ConfigurationItem.scope_uri`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,7 +502,7 @@ pub struct ConfigurationParams {
 pub struct ConfigurationItem {
     /// The scope to get the configuration section for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scope_uri: Option<String>,
+    pub scope_uri: Option<Url>,
 
     ///The configuration section asked for.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
```typescript
export interface ConfigurationItem {
	/**
	 * The scope to get the configuration section for.
	 */
	scopeUri?: DocumentUri;

	/**
	 * The configuration section asked for.
	 */
	section?: string;
}
```
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_configuration