### PR TITLE
New proposed features for LSP 3.16, missing fields and clarification on numerics

### DIFF
--- a/src/code_action.rs
+++ b/src/code_action.rs
@@ -3,6 +3,8 @@ use crate::{
     WorkDoneProgressOptions, WorkDoneProgressParams, WorkspaceEdit,
 };
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "proposed")]
 use serde_json::Value;
 
 use std::borrow::Cow;

--- a/src/code_lens.rs
+++ b/src/code_lens.rs
@@ -30,6 +30,7 @@ pub struct CodeLensParams {
 /// A code lens is _unresolved_ when no command is associated to it. For performance
 /// reasons the creation of a code lens and resolving should be done in two stages.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeLens {
     /// The range in which this code lens is valid. Should only span a single line.
     pub range: Range,
@@ -42,4 +43,15 @@ pub struct CodeLens {
     /// a code lens and a code lens resolve request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct CodeLensWorkspaceClientCapabilities {
+    /// Whether the client implementation supports a refresh request send from the server
+    /// to the client. This is useful if a server detects a change which requires a
+    /// re-calculation of all code lenses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_support: Option<bool>,
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -71,13 +71,13 @@ pub struct ColorInformation {
 #[serde(rename_all = "camelCase")]
 pub struct Color {
     /// The red component of this color in the range [0-1].
-    pub red: f64,
+    pub red: f32,
     /// The green component of this color in the range [0-1].
-    pub green: f64,
+    pub green: f32,
     /// The blue component of this color in the range [0-1].
-    pub blue: f64,
+    pub blue: f32,
     /// The alpha component of this color in the range [0-1].
-    pub alpha: f64,
+    pub alpha: f32,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -153,8 +153,8 @@ pub enum InsertTextMode {
     /// which the item is accepted.
     ///
     /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
-    /// multi line completion item is indented using 3 tabs all
-    /// following lines inserted will be indented using 3 tabs as well.
+    /// multi line completion item is indented using 2 tabs all
+    /// following lines inserted will be indented using 2 tabs as well.
     AdjustIndentation = 2,
 }
 

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -384,6 +384,12 @@ pub struct CompletionItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_text_format: Option<InsertTextFormat>,
 
+    /// How whitespace and indentation is handled during completion item insertion.
+    /// If ignored the clients default value depends on the `textDocument.completion.insertTextMode` client capability.
+    #[cfg(feature = "proposed")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub insert_text_mode: Option<InsertTextMode>,
+
     /// An edit which is applied to a document when selecting
     /// this completion. When an edit is provided the value of
     /// insertText is ignored.

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -149,11 +149,11 @@ pub enum InsertTextMode {
     AsIs = 1,
 
     /// The editor adjusts leading whitespace of new lines so that
-    /// they match the indentation of the line for which the item
-    /// is accepted.
+    /// they match the indentation up to the cursor of the line for
+    /// which the item is accepted.
     ///
-    /// For example if the line containing the cursor when a accepting
-    /// a multi line completion item is indented using 3 tabs all
+    /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
+    /// multi line completion item is indented using 3 tabs all
     /// following lines inserted will be indented using 3 tabs as well.
     AdjustIndentation = 2,
 }
@@ -385,7 +385,7 @@ pub struct CompletionItem {
     pub insert_text_format: Option<InsertTextFormat>,
 
     /// How whitespace and indentation is handled during completion item insertion.
-    /// If ignored the clients default value depends on the `textDocument.completion.insertTextMode` client capability.
+    /// If not provided the clients default value depends on the `textDocument.completion.insertTextMode` client capability.
     #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_text_mode: Option<InsertTextMode>,

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -107,6 +107,15 @@ pub struct CompletionItemCapability {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "proposed")]
     pub resolve_support: Option<CompletionItemCapabilityResolveSupport>,
+
+    /// The client supports the `insertTextMode` property on
+    /// a completion item to override the whitespace handling mode
+    /// as defined by the client (see `insertTextMode`).
+    ///
+    /// @since 3.16.0 - proposed state
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "proposed")]
+    pub insert_text_mode_support: Option<InsertTextModeSupport>,
 }
 
 #[cfg(feature = "proposed")]
@@ -115,6 +124,38 @@ pub struct CompletionItemCapability {
 pub struct CompletionItemCapabilityResolveSupport {
     /// The properties that a client can resolve lazily.
     pub properties: Vec<String>,
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InsertTextModeSupport {
+    pub value_set: Vec<InsertTextMode>,
+}
+
+/// How whitespace and indentation is handled during completion
+/// item insertion.
+///
+/// @since 3.16.0 - proposed state
+#[cfg(feature = "proposed")]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum InsertTextMode {
+    /// The insertion or replace strings is taken as it is. If the
+    /// value is multi line the lines below the cursor will be
+    /// inserted using the indentation defined in the string value.
+    /// The client will not apply any kind of adjustments to the
+    /// string.
+    AsIs = 1,
+
+    /// The editor adjusts leading whitespace of new lines so that
+    /// they match the indentation of the line for which the item
+    /// is accepted.
+    ///
+    /// For example if the line containing the cursor when a accepting
+    /// a multi line completion item is indented using 3 tabs all
+    /// following lines inserted will be indented using 3 tabs as well.
+    AdjustIndentation = 2,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize_repr, Serialize_repr)]

--- a/src/folding_range.rs
+++ b/src/folding_range.rs
@@ -57,7 +57,7 @@ pub struct FoldingRangeCapability {
     /// The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
     /// hint, servers are free to follow the limit.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub range_limit: Option<u64>,
+    pub range_limit: Option<u32>,
     /// If set, the client signals that it only supports folding complete lines. If set, client will
     /// ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,18 +81,18 @@ pub enum FoldingRangeKind {
 #[serde(rename_all = "camelCase")]
 pub struct FoldingRange {
     /// The zero-based line number from where the folded range starts.
-    pub start_line: u64,
+    pub start_line: u32,
 
     /// The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_character: Option<u64>,
+    pub start_character: Option<u32>,
 
     /// The zero-based line number where the folded range ends.
-    pub end_line: u64,
+    pub end_line: u32,
 
     /// The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_character: Option<u64>,
+    pub end_character: Option<u32>,
 
     /// Describes the kind of the folding range such as `comment' or 'region'. The kind
     /// is used to categorize folding ranges and used by commands like 'Fold all comments'. See

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -37,7 +37,7 @@ pub struct DocumentFormattingParams {
 #[serde(rename_all = "camelCase")]
 pub struct FormattingOptions {
     /// Size of a tab in spaces.
-    pub tab_size: u64,
+    pub tab_size: u32,
 
     /// Prefer spaces over tabs.
     pub insert_spaces: bool,
@@ -63,7 +63,7 @@ pub struct FormattingOptions {
 #[serde(untagged)]
 pub enum FormattingProperty {
     Bool(bool),
-    Number(f64),
+    Number(i32),
     String(String),
 }
 
@@ -136,14 +136,14 @@ mod tests {
             &FormattingOptions {
                 tab_size: 123,
                 insert_spaces: true,
-                properties: vec![("prop".to_string(), FormattingProperty::Number(1.0))]
+                properties: vec![("prop".to_string(), FormattingProperty::Number(1))]
                     .into_iter()
                     .collect(),
                 trim_trailing_whitespace: None,
                 insert_final_newline: None,
                 trim_final_newlines: None,
             },
-            r#"{"tabSize":123,"insertSpaces":true,"prop":1.0}"#,
+            r#"{"tabSize":123,"insertSpaces":true,"prop":1}"#,
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1004,6 +1004,12 @@ pub struct WorkspaceClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "proposed")]
     pub semantic_tokens: Option<SemanticTokensWorkspaceClientCapabilities>,
+
+    /// Capabilities specific to the code lens requests scoped to the workspace.
+    /// since 3.16.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "proposed")]
+    pub code_lens: Option<CodeLensWorkspaceClientCapabilities>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -780,6 +780,8 @@ pub struct InitializeParams {
     /// The rootUri of the workspace. Is null if no
     /// folder is open. If both `rootPath` and `rootUri` are set
     /// `rootUri` wins.
+    ///
+    /// Deprecated in favour of `workspaceFolders`
     #[serde(default)]
     pub root_uri: Option<Url>,
 
@@ -1247,9 +1249,34 @@ pub struct ClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub window: Option<WindowClientCapabilities>,
 
+    /// General client capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "proposed")]
+    pub general: Option<GeneralClientCapabilities>,
+
     /// Experimental client capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<Value>,
+}
+
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg(feature = "proposed")]
+pub struct GeneralClientCapabilities {
+    /// Client capabilities specific to regular expressions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regular_expressions: Option<RegularExpressionsClientCapabilities>,
+}
+
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg(feature = "proposed")]
+pub struct RegularExpressionsClientCapabilities {
+    /// The engine's name.
+    pub engine: String,
+
+    /// The engine's version
+    pub version: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ pub struct InitializeParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initialization_options: Option<Value>,
 
-    /// The capabilities provided by the client (editor)
+    /// The capabilities provided by the client (editor or tool)
     pub capabilities: ClientCapabilities,
 
     /// The initial trace setting. If omitted trace is disabled ('off').
@@ -797,6 +797,18 @@ pub struct InitializeParams {
     /// Information about the client.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_info: Option<ClientInfo>,
+
+    /// The locale the client is currently showing the user interface
+    /// in. This must not necessarily be the locale of the operating
+    /// system.
+    ///
+    /// Uses IETF language tags as the value's syntax
+    /// (See https://en.wikipedia.org/wiki/IETF_language_tag)
+    ///
+    /// @since 3.16.0 - proposed state
+    #[cfg(feature = "proposed")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ pub use semantic_tokens::*;
 mod signature_help;
 pub use signature_help::*;
 
+mod window;
+pub use window::*;
+
 mod workspace_folders;
 pub use workspace_folders::*;
 
@@ -1223,47 +1226,6 @@ pub struct TextDocumentClientCapabilities {
     pub semantic_tokens: Option<SemanticTokensClientCapabilities>,
 }
 
-/// Window specific client capabilities.
-#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WindowClientCapabilities {
-    /// Whether client supports handling progress notifications. If set
-    /// servers are allowed to report in `workDoneProgress` property in the
-    /// request specific server capabilities.
-    ///
-    /// @since 3.15.0
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_done_progress: Option<bool>,
-
-    /// Capabilities specific to the showMessage request
-    ///
-    /// @since 3.16.0 - proposed state
-    ///
-    #[cfg(feature = "proposed")]
-    pub show_message: ShowMessageRequestClientCapabilities,
-}
-
-/// Show message request client capabilities
-#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
-#[cfg(feature = "proposed")]
-#[serde(rename_all = "camelCase")]
-pub struct ShowMessageRequestClientCapabilities {
-    /// Capabilities specific to the `MessageActionItem` type.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_action_item: Option<MessageActionItemCapabilities>,
-}
-
-#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
-#[cfg(feature = "proposed")]
-#[serde(rename_all = "camelCase")]
-pub struct MessageActionItemCapabilities {
-    /// Whether the client supports additional attribues which
-    /// are preserved and send back to the server in the
-    /// request's response.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_properties_support: Option<bool>,
-}
-
 /// Where ClientCapabilities are currently empty:
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1574,77 +1536,6 @@ pub struct ServerCapabilities {
     /// Experimental server capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<Value>,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-pub struct ShowMessageParams {
-    /// The message type. See {@link MessageType}.
-    #[serde(rename = "type")]
-    pub typ: MessageType,
-
-    /// The actual message.
-    pub message: String,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize_repr, Serialize_repr)]
-#[repr(u8)]
-pub enum MessageType {
-    /// An error message.
-    Error = 1,
-    /// A warning message.
-    Warning = 2,
-    /// An information message.
-    Info = 3,
-    /// A log message.
-    Log = 4,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-pub struct ShowMessageRequestParams {
-    /// The message type. See {@link MessageType}
-    #[serde(rename = "type")]
-    pub typ: MessageType,
-
-    /// The actual message
-    pub message: String,
-
-    /// The message action items to present.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub actions: Option<Vec<MessageActionItem>>,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MessageActionItem {
-    /// A short title like 'Retry', 'Open Log' etc.
-    pub title: String,
-
-    /// Additional attributes that the client preserves and
-    /// sends back to the server. This depends on the client
-    /// capability window.messageActionItem.additionalPropertiesSupport
-    #[cfg(feature = "proposed")]
-    #[serde(flatten)]
-    pub properties: HashMap<String, MessageActionItemProperty>,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[cfg(feature = "proposed")]
-#[serde(untagged)]
-pub enum MessageActionItemProperty {
-    String(String),
-    Boolean(bool),
-    Integer(i64),
-    Object(Value),
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-pub struct LogMessageParams {
-    /// The message type. See {@link MessageType}
-    #[serde(rename = "type")]
-    pub typ: MessageType,
-
-    /// The actual message
-    pub message: String,
 }
 
 /// General parameters to to register for a capability.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1251,6 +1251,12 @@ pub struct TextDocumentClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub folding_range: Option<FoldingRangeCapability>,
 
+    /// Capabilities specific to the `textDocument/selectionRange` request.
+    ///
+    /// @since 3.15.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_range: Option<SelectionRangeClientCapabilities>,
+
     /// The client's semantic highlighting capability.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "proposed")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1227,9 +1227,41 @@ pub struct TextDocumentClientCapabilities {
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WindowClientCapabilities {
-    /// Whether client supports create a work done progress UI from the server side.
+    /// Whether client supports handling progress notifications. If set
+    /// servers are allowed to report in `workDoneProgress` property in the
+    /// request specific server capabilities.
+    ///
+    /// @since 3.15.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_done_progress: Option<bool>,
+
+    /// Capabilities specific to the showMessage request
+    ///
+    /// @since 3.16.0 - proposed state
+    ///
+    #[cfg(feature = "proposed")]
+    pub show_message: ShowMessageRequestClientCapabilities,
+}
+
+/// Show message request client capabilities
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct ShowMessageRequestClientCapabilities {
+    /// Capabilities specific to the `MessageActionItem` type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_action_item: Option<MessageActionItemCapabilities>,
+}
+
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct MessageActionItemCapabilities {
+    /// Whether the client supports additional attribues which
+    /// are preserved and send back to the server in the
+    /// request's response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_properties_support: Option<bool>,
 }
 
 /// Where ClientCapabilities are currently empty:
@@ -1582,9 +1614,27 @@ pub struct ShowMessageRequestParams {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageActionItem {
     /// A short title like 'Retry', 'Open Log' etc.
     pub title: String,
+
+    /// Additional attributes that the client preserves and
+    /// sends back to the server. This depends on the client
+    /// capability window.messageActionItem.additionalPropertiesSupport
+    #[cfg(feature = "proposed")]
+    #[serde(flatten)]
+    pub properties: HashMap<String, MessageActionItemProperty>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(untagged)]
+pub enum MessageActionItemProperty {
+    String(String),
+    Boolean(bool),
+    Integer(i64),
+    Object(Value),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,6 +891,17 @@ pub struct WorkspaceEditCapability {
     /// failes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_handling: Option<FailureHandlingKind>,
+
+    /// Whether the client normalizes line endings to the client specific
+    /// setting.
+    /// If set to `true` the client will normalize line ending characters
+    /// in a workspace edit containg to the client specific new line
+    /// character.
+    ///
+    /// @since 3.16.0 - proposed state
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "proposed")]
+    pub normalizes_line_endings: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize, Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,11 @@ pub use semantic_tokens::*;
 mod signature_help;
 pub use signature_help::*;
 
+#[cfg(feature = "proposed")]
+mod type_rename;
+#[cfg(feature = "proposed")]
+pub use type_rename::*;
+
 mod window;
 pub use window::*;
 
@@ -1257,6 +1262,13 @@ pub struct TextDocumentClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selection_range: Option<SelectionRangeClientCapabilities>,
 
+    /// Capabilities specific to `textDocument/onTypeRename` requests.
+    ///
+    /// @since 3.16.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "proposed")]
+    pub on_type_rename: Option<OnTypeRenameClientCapabilities>,
+
     /// The client's semantic highlighting capability.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "proposed")]
@@ -1599,6 +1611,13 @@ pub struct ServerCapabilities {
     #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semantic_tokens_provider: Option<SemanticTokensServerCapabilities>,
+
+    /// The server provides on type rename support.
+    ///
+    /// @since 3.16.0 - proposed state
+    #[cfg(feature = "proposed")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_type_rename_provider: Option<OnTypeRenameServerCapabilities>,
 
     /// Experimental server capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2018,15 +2018,36 @@ pub struct ExecuteCommandRegistrationOptions {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApplyWorkspaceEditParams {
+    /// An optional label of the workspace edit. This label is
+    /// presented in the user interface for example on an undo
+    /// stack to undo the workspace edit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+
     /// The edits to apply.
     pub edit: WorkspaceEdit,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApplyWorkspaceEditResponse {
     /// Indicates whether the edit was applied or not.
     pub applied: bool,
+
+    /// An optional textual description for why the edit was not applied.
+    /// This may be used may be used by the server for diagnostic
+    /// logging or to provide a suitable error for a request that
+    /// triggered the edit
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+
+    /// Depending on the client's failure handling strategy `failedChange` might
+    ///contain the index of the change that failed. This property is only available
+    /// if the client signals a `failureHandlingStrategy` in its client capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_change: Option<u32>,
 }
 
 /// Describes the content type that a client supports in various

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -127,6 +127,8 @@ impl Notification for LogMessage {
 }
 
 /// The telemetry notification is sent from the server to the client to ask the client to log a telemetry event.
+/// The protocol doesn't specify the payload since no interpretation of the data happens in the protocol. Most clients even don't handle
+/// the event directly but forward them to the extensions owning the corresponding server issuing the event.
 #[derive(Debug)]
 pub enum TelemetryEvent {}
 
@@ -195,8 +197,10 @@ impl Notification for DidSaveTextDocument {
     const METHOD: &'static str = "textDocument/didSave";
 }
 
-/// The watched files notification is sent from the client to the server when the client detects changes to files
-/// watched by the language client.
+/// The watched files notification is sent from the client to the server when the client detects changes to files and folders
+/// watched by the language client (note although the name suggest that only file events are sent it is about file system events which include folders as well).
+/// It is recommended that servers register for these file system events using the registration mechanism.
+/// In former implementations clients pushed file events without the server actively asking for it.
 #[derive(Debug)]
 pub enum DidChangeWatchedFiles {}
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -72,15 +72,20 @@ pub struct WorkDoneProgressBegin {
 
     /// Optional, more detailed associated progress message. Contains
     /// complementary information to the `title`.
+    ///
     /// Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".
     /// If unset, the previous progress message (if any) is still valid.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 
     /// Optional progress percentage to display (value 100 is considered 100%).
-    /// If unset, the previous progress percentage (if any) is still valid.
+    /// If not provided infinite progress is assumed and clients are allowed
+    /// to ignore the `percentage` value in subsequent in report notifications.
+    ///
+    /// The value should be steadily rising. Clients are free to ignore values
+    /// that are not following this rule. The value range is [0, 100]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub percentage: Option<f64>,
+    pub percentage: Option<u32>,
 }
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
@@ -100,9 +105,13 @@ pub struct WorkDoneProgressReport {
     pub message: Option<String>,
 
     /// Optional progress percentage to display (value 100 is considered 100%).
-    /// If unset, the previous progress percentage (if any) is still valid.
+    /// If not provided infinite progress is assumed and clients are allowed
+    /// to ignore the `percentage` value in subsequent in report notifications.
+    ///
+    /// The value should be steadily rising. Clients are free to ignore values
+    /// that are not following this rule. The value range is [0, 100]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub percentage: Option<f64>,
+    pub percentage: Option<u32>,
 }
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -55,7 +55,12 @@ pub struct RenameCapability {
 #[serde(rename_all = "camelCase")]
 pub enum PrepareRenameResponse {
     Range(Range),
-    RangeWithPlaceholder { range: Range, placeholder: String },
+    RangeWithPlaceholder {
+        range: Range,
+        placeholder: String,
+    },
     #[cfg(feature = "proposed")]
-    DefaultBehavior { default_behavior: bool },
+    DefaultBehavior {
+        default_behavior: bool,
+    },
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -162,6 +162,10 @@ macro_rules! lsp_request {
     ("codeAction/resolve") => {
         $crate::request::CodeActionResolveRequest
     };
+    // Requires #[cfg(feature = "proposed")]
+    ("window/showDocument") => {
+        $crate::request::ShowDocument
+    };
 }
 
 /// The initialize request is sent as the first request from the client to the server.
@@ -722,6 +726,17 @@ impl Request for CodeLensRefresh {
     const METHOD: &'static str = "workspace/codeLens/refresh";
 }
 
+#[cfg(feature = "proposed")]
+/// The show document request is sent from a server to a client to ask the client to display a particular document in the user interface.
+pub enum ShowDocument {}
+
+#[cfg(feature = "proposed")]
+impl Request for ShowDocument {
+    type Params = ShowDocumentParams;
+    type Result = ShowDocumentResult;
+    const METHOD: &'static str = "window/showDocument";
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -794,6 +809,7 @@ mod test {
         check_macro!("textDocument/semanticTokens/full");
         check_macro!("textDocument/semanticTokens/full/delta");
         check_macro!("textDocument/semanticTokens/range");
+        check_macro!("window/showDocument");
         check_macro!("workspace/semanticTokens/refresh");
         check_macro!("workspace/codeLens/refresh");
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -155,6 +155,10 @@ macro_rules! lsp_request {
         $crate::request::SemanticTokensRefesh
     };
     // Requires #[cfg(feature = "proposed")]
+    ("workspace/codeLens/refresh") => {
+        $crate::request::CodeLensRefresh
+    };
+    // Requires #[cfg(feature = "proposed")]
     ("codeAction/resolve") => {
         $crate::request::CodeActionResolveRequest
     };
@@ -703,6 +707,21 @@ impl Request for SemanticTokensRefesh {
     const METHOD: &'static str = "workspace/semanticTokens/refresh";
 }
 
+#[cfg(feature = "proposed")]
+/// The workspace/codeLens/refresh request is sent from the server to the client.
+/// Servers can use it to ask clients to refresh the code lenses currently shown in editors.
+/// As a result the client should ask the server to recompute the code lenses for these editors.
+/// This is useful if a server detects a configuration change which requires a re-calculation of all code lenses.
+/// Note that the client still has the freedom to delay the re-calculation of the code lenses if for example an editor is currently not visible.
+pub enum CodeLensRefresh {}
+
+#[cfg(feature = "proposed")]
+impl Request for CodeLensRefresh {
+    type Params = ();
+    type Result = ();
+    const METHOD: &'static str = "workspace/codeLens/refresh";
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -776,5 +795,6 @@ mod test {
         check_macro!("textDocument/semanticTokens/full/delta");
         check_macro!("textDocument/semanticTokens/range");
         check_macro!("workspace/semanticTokens/refresh");
+        check_macro!("workspace/codeLens/refresh");
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -134,6 +134,9 @@ macro_rules! lsp_request {
     ("callHierarchy/outgoingCalls") => {
         $crate::request::CallHierarchyOutgoingCalls
     };
+    ("textDocument/onTypeRename") => {
+        $crate::request::OnTypeRename
+    };
     // Requires #[cfg(feature = "proposed")]
     ("textDocument/prepareCallHierarchy") => {
         $crate::request::CallHierarchyPrepare
@@ -543,6 +546,22 @@ impl Request for OnTypeFormatting {
     const METHOD: &'static str = "textDocument/onTypeFormatting";
 }
 
+/// The on type rename request is sent from the client to the server to return for a given position in a document
+/// the range of the symbol at the position and all ranges that have the same content and can be renamed together.
+/// Optionally a word pattern can be returned to describe valid contents. A rename to one of the ranges can be applied
+/// to all other ranges if the new content is valid. If no result-specific word pattern is provided, the word pattern from
+/// the client’s language configuration is used.
+#[cfg(feature = "proposed")]
+#[derive(Debug)]
+pub enum OnTypeRename {}
+
+#[cfg(feature = "proposed")]
+impl Request for OnTypeRename {
+    type Params = OnTypeRenameParams;
+    type Result = Option<OnTypeRenameRanges>;
+    const METHOD: &'static str = "textDocument/onTypeRename";
+}
+
 /// The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
 #[derive(Debug)]
 pub enum Rename {}
@@ -805,6 +824,7 @@ mod test {
         check_macro!("callHierarchy/incomingCalls");
         check_macro!("callHierarchy/outgoingCalls");
         check_macro!("codeAction/resolve");
+        check_macro!("textDocument/onTypeRename");
         check_macro!("textDocument/prepareCallHierarchy");
         check_macro!("textDocument/semanticTokens/full");
         check_macro!("textDocument/semanticTokens/full/delta");

--- a/src/selection_range.rs
+++ b/src/selection_range.rs
@@ -4,6 +4,16 @@ use crate::{
     PartialResultParams, Position, Range, StaticTextDocumentRegistrationOptions,
     TextDocumentIdentifier, WorkDoneProgressOptions, WorkDoneProgressParams,
 };
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionRangeClientCapabilities {
+    /// Whether implementation supports dynamic registration for selection range
+    /// providers. If this is set to `true` the client supports the new
+    /// `SelectionRangeRegistrationOptions` return value for the corresponding
+    /// server capability as well.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dynamic_registration: Option<bool>,
+}
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 pub struct SelectionRangeOptions {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -349,8 +349,14 @@ pub struct SemanticTokensClientCapabilities {
     /// The token modifiers that the client supports.
     pub token_modifiers: Vec<SemanticTokenModifier>,
 
-    /// The formats the clients supports.
+    /// The token formats the clients supports.
     pub formats: Vec<TokenFormat>,
+
+    /// Whether the client supports tokens that can overlap each other.
+    pub overlapping_token_support: Option<bool>,
+
+    /// Whether the client supports tokens that can span multiple lines.
+    pub multiline_token_support: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -353,9 +353,11 @@ pub struct SemanticTokensClientCapabilities {
     pub formats: Vec<TokenFormat>,
 
     /// Whether the client supports tokens that can overlap each other.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub overlapping_token_support: Option<bool>,
 
     /// Whether the client supports tokens that can span multiple lines.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub multiline_token_support: Option<bool>,
 }
 

--- a/src/signature_help.rs
+++ b/src/signature_help.rs
@@ -144,11 +144,11 @@ pub struct SignatureHelp {
 
     /// The active signature.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_signature: Option<i64>,
+    pub active_signature: Option<u32>,
 
     /// The active parameter of the active signature.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_parameter: Option<i64>,
+    pub active_parameter: Option<u32>,
 }
 
 /// Represents the signature of something callable. A signature
@@ -176,7 +176,7 @@ pub struct SignatureInformation {
     /// @since 3.16.0 - proposed state
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "proposed")]
-    pub active_parameter: Option<i64>,
+    pub active_parameter: Option<u32>,
 }
 
 /// Represents a parameter of a callable-signature. A parameter can
@@ -200,5 +200,5 @@ pub struct ParameterInformation {
 #[serde(untagged)]
 pub enum ParameterLabel {
     Simple(String),
-    LabelOffsets([u64; 2]),
+    LabelOffsets([u32; 2]),
 }

--- a/src/type_rename.rs
+++ b/src/type_rename.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    GenericCapability, Range, StaticRegistrationOptions, TextDocumentPositionParams,
+    TextDocumentRegistrationOptions, WorkDoneProgressOptions, WorkDoneProgressParams,
+};
+
+pub type OnTypeRenameClientCapabilities = GenericCapability;
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnTypeRenameOptions {
+    #[serde(flatten)]
+    pub work_done_progress_options: WorkDoneProgressOptions,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnTypeRenameRegistrationOptions {
+    #[serde(flatten)]
+    pub text_document_registration_options: TextDocumentRegistrationOptions,
+
+    #[serde(flatten)]
+    pub on_type_rename_options: OnTypeRenameOptions,
+
+    #[serde(flatten)]
+    pub static_registration_options: StaticRegistrationOptions,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum OnTypeRenameServerCapabilities {
+    Options(OnTypeRenameOptions),
+    RegistrationOptions(OnTypeRenameRegistrationOptions),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnTypeRenameParams {
+    #[serde(flatten)]
+    pub text_document_position_params: TextDocumentPositionParams,
+
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnTypeRenameRanges {
+    /// A list of ranges that can be renamed together. The ranges must have
+    /// identical length and contain identical text content. The ranges cannot overlap.
+    pub ranges: Vec<Range>,
+
+    /// An optional word pattern (regular expression) that describes valid contents for
+    /// the given ranges. If no pattern is provided, the client configuration's word
+    /// pattern will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub word_pattern: Option<String>,
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -38,7 +38,8 @@ pub struct WindowClientCapabilities {
     /// @since 3.16.0 - proposed state
     ///
     #[cfg(feature = "proposed")]
-    pub show_message: ShowMessageRequestClientCapabilities,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_message: Option<ShowMessageRequestClientCapabilities>,
 }
 
 /// Show message request client capabilities

--- a/src/window.rs
+++ b/src/window.rs
@@ -82,7 +82,7 @@ pub struct MessageActionItem {
 pub enum MessageActionItemProperty {
     String(String),
     Boolean(bool),
-    Integer(i64),
+    Integer(i32),
     Object(Value),
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,6 +8,12 @@ use serde_json::Value;
 
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
+#[cfg(feature = "proposed")]
+use url::Url;
+
+#[cfg(feature = "proposed")]
+use crate::Range;
+
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize_repr, Serialize_repr)]
 #[repr(u8)]
 pub enum MessageType {
@@ -33,13 +39,21 @@ pub struct WindowClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_done_progress: Option<bool>,
 
-    /// Capabilities specific to the showMessage request
+    /// Capabilities specific to the showMessage request.
     ///
     /// @since 3.16.0 - proposed state
     ///
     #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_message: Option<ShowMessageRequestClientCapabilities>,
+
+    /// Client capabilities for the show document request.
+    ///
+    /// @since 3.16.0 - proposed state
+    ///
+    #[cfg(feature = "proposed")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_document: Option<ShowDocumentClientCapabilities>,
 }
 
 /// Show message request client capabilities
@@ -119,4 +133,56 @@ pub struct ShowMessageRequestParams {
     /// The message action items to present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actions: Option<Vec<MessageActionItem>>,
+}
+
+/// Client capabilities for the show document request.
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct ShowDocumentClientCapabilities {
+    /// The client has support for the show document request.
+    pub support: bool,
+}
+
+/// Params to show a document.
+///
+/// @since 3.16.0 - proposed state
+///
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct ShowDocumentParams {
+    /// The document uri to show.
+    pub uri: Url,
+
+    /// Indicates to show the resource in an external program.
+    /// To show for example `https://code.visualstudio.com/`
+    /// in the default WEB browser set `external` to `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external: Option<bool>,
+
+    ///  An optional property to indicate whether the editor
+    ///  showing the document should take focus or not.
+    ///  Clients might ignore this property if an external
+    ///  program in started.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub take_focus: Option<bool>,
+
+    ///  An optional selection range if the document is a text
+    ///  document. Clients might ignore the property if an
+    ///  external program is started or the file is not a text
+    ///  file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection: Option<Range>,
+}
+
+/// The result of an show document request.
+///
+/// @since 3.16.0 - proposed state
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct ShowDocumentResult {
+    /// A boolean indicating if the show was successful.
+    pub success: bool,
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,0 +1,121 @@
+#[cfg(feature = "proposed")]
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "proposed")]
+use serde_json::Value;
+
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize_repr, Serialize_repr)]
+#[repr(u8)]
+pub enum MessageType {
+    /// An error message.
+    Error = 1,
+    /// A warning message.
+    Warning = 2,
+    /// An information message.
+    Info = 3,
+    /// A log message.
+    Log = 4,
+}
+
+/// Window specific client capabilities.
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowClientCapabilities {
+    /// Whether client supports handling progress notifications. If set
+    /// servers are allowed to report in `workDoneProgress` property in the
+    /// request specific server capabilities.
+    ///
+    /// @since 3.15.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_done_progress: Option<bool>,
+
+    /// Capabilities specific to the showMessage request
+    ///
+    /// @since 3.16.0 - proposed state
+    ///
+    #[cfg(feature = "proposed")]
+    pub show_message: ShowMessageRequestClientCapabilities,
+}
+
+/// Show message request client capabilities
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct ShowMessageRequestClientCapabilities {
+    /// Capabilities specific to the `MessageActionItem` type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_action_item: Option<MessageActionItemCapabilities>,
+}
+
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(rename_all = "camelCase")]
+pub struct MessageActionItemCapabilities {
+    /// Whether the client supports additional attribues which
+    /// are preserved and send back to the server in the
+    /// request's response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_properties_support: Option<bool>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageActionItem {
+    /// A short title like 'Retry', 'Open Log' etc.
+    pub title: String,
+
+    /// Additional attributes that the client preserves and
+    /// sends back to the server. This depends on the client
+    /// capability window.messageActionItem.additionalPropertiesSupport
+    #[cfg(feature = "proposed")]
+    #[serde(flatten)]
+    pub properties: HashMap<String, MessageActionItemProperty>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg(feature = "proposed")]
+#[serde(untagged)]
+pub enum MessageActionItemProperty {
+    String(String),
+    Boolean(bool),
+    Integer(i64),
+    Object(Value),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct LogMessageParams {
+    /// The message type. See {@link MessageType}
+    #[serde(rename = "type")]
+    pub typ: MessageType,
+
+    /// The actual message
+    pub message: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct ShowMessageParams {
+    /// The message type. See {@link MessageType}.
+    #[serde(rename = "type")]
+    pub typ: MessageType,
+
+    /// The actual message.
+    pub message: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct ShowMessageRequestParams {
+    /// The message type. See {@link MessageType}
+    #[serde(rename = "type")]
+    pub typ: MessageType,
+
+    /// The actual message
+    pub message: String,
+
+    /// The message action items to present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<Vec<MessageActionItem>>,
+}


### PR DESCRIPTION
Each commits adds a separate feature.
Adds missing fields in `ApplyWorkspaceEdit`
Uses newly clarified numeric types
Adds `workspace/codeLens/refresh`
Adds `window/showDocument`

Best reviewed by commit.

cc @matklad