### PR TITLE
Fix DidSaveTextDocumentParams::text_document to use TextDocumentIdentifier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1956,7 +1956,7 @@ pub struct DidCloseTextDocumentParams {
 #[serde(rename_all = "camelCase")]
 pub struct DidSaveTextDocumentParams {
     /// The document that was saved.
-    pub text_document: VersionedTextDocumentIdentifier,
+    pub text_document: TextDocumentIdentifier,
 
     /// Optional the content when saved. Depends on the includeText value
     /// when the save notification was requested.


### PR DESCRIPTION
After microsoft/language-server-protocol#1147 and rust-analyzer/rust-analyzer#6603, here is the change this will bring to the spec.