### PR TITLE
Support deserializing old change_annotation_support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1047,7 +1047,31 @@ pub struct WorkspaceEditClientCapabilities {
     ///
     /// @since 3.16.0
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(deserialize_with = "deserialize_change_annotation_support")]
     pub change_annotation_support: Option<ChangeAnnotationWorkspaceEditClientCapabilities>,
+}
+
+fn deserialize_change_annotation_support<'de, D>(
+    d: D,
+) -> Result<Option<ChangeAnnotationWorkspaceEditClientCapabilities>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Bool(bool),
+        Obj(ChangeAnnotationWorkspaceEditClientCapabilities),
+    }
+    Option::<Repr>::deserialize(d).map(|repr| {
+        repr.and_then(|repr| match repr {
+            Repr::Bool(true) => Some(ChangeAnnotationWorkspaceEditClientCapabilities {
+                groups_on_labels: None,
+            }),
+            Repr::Bool(false) => None,
+            Repr::Obj(it) => Some(it),
+        })
+    })
 }
 
 #[derive(Debug, Eq, PartialEq, Deserialize, Serialize, Copy, Clone)]


### PR DESCRIPTION
Option<bool> was used in a preview version of the protocol, and might
still be send by some clients, notbaly, VS Code with pre-release
version of lsp library.

Not sure if it makes to merge this:

* On the one hand, current code is a-ok with respect to respecting the actual release protocol, and what happens during proposed, stays there
* On the other hand, we have a very real problem in rust-analyzer when users of VS Code 1.51 are faced with a startup crash, because rust-analyzer plugin in that version uses old version of the procotol. As a result, today's release of rust-analyzer will use my fork of lsp-types with this patch applied. 


Overall, :man_shrugging: 