### PR TITLE
Fix wrong doc comment for server_info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1469,7 +1469,7 @@ pub struct InitializeResult {
     /// The capabilities the language server provides.
     pub capabilities: ServerCapabilities,
 
-    /// The capabilities the language server provides.
+    /// Information about the server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_info: Option<ServerInfo>,
 


### PR DESCRIPTION
Replaced with the comment from the specification.  

I couldn't find any other mistakenly repeated doc comments.