### PR TITLE
Allow plain bool in server capability "linkedEditingRangeProvider"

### DIFF
--- a/src/linked_editing.rs
+++ b/src/linked_editing.rs
@@ -31,6 +31,7 @@ pub struct LinkedEditingRangeRegistrationOptions {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum LinkedEditingRangeServerCapabilities {
+    Simple(bool),
     Options(LinkedEditingRangeOptions),
     RegistrationOptions(LinkedEditingRangeRegistrationOptions),
 }


### PR DESCRIPTION
The [spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/) says:

	interface ServerCapabilities {
		...

		linkedEditingRangeProvider?: boolean | LinkedEditingRangeOptions
				| LinkedEditingRangeRegistrationOptions;
	}

Add an enum variant for bool. This is consistent with "FoldingRangeProviderCapability".

Originally reported at https://github.com/kak-lsp/kak-lsp/issues/484