### PR TITLE
Fix PrepareRenameResponse casing issue

### DIFF
--- a/src/rename.rs
+++ b/src/rename.rs
@@ -77,5 +77,6 @@ pub enum PrepareSupportDefaultBehavior {
 pub enum PrepareRenameResponse {
     Range(Range),
     RangeWithPlaceholder { range: Range, placeholder: String },
+    #[serde(rename_all = "camelCase")]
     DefaultBehavior { default_behavior: bool },
 }


### PR DESCRIPTION
The `default_behaviour` field in `PrepareRenameResponse` is not being renamed to camel_case, see: https://github.com/gluon-lang/lsp-types/blob/master/src/rename.rs#L80

Adding a serde annotation solves this.