### PR TITLE
Add constants for lsp specific error codes

### DIFF
--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -1,0 +1,37 @@
+//! In this module we only define constants for lsp specific error codes.
+//! There are other error codes that are defined in the
+//! [JSON RPC specification](https://www.jsonrpc.org/specification#error_object).
+
+// This is the start range of LSP reserved error codes.
+// It doesn't denote a real error code.
+//
+// @since 3.16.0
+pub const lspReservedErrorRangeStart: i64 = -32899;
+
+// The server cancelled the request. This error code should
+// only be used for requests that explicitly support being
+// server cancellable.
+//
+// @since 3.17.0
+#[cfg(feature = "proposed")]
+pub const ServerCancelled: i64 = -32802;
+ 
+// The server detected that the content of a document got
+// modified outside normal conditions. A server should
+// NOT send this error code if it detects a content change
+// in it unprocessed messages. The result even computed
+// on an older state might still be useful for the client.
+//
+// If a client decides that a result is not of any use anymore
+// the client should cancel the request.
+pub const ContentModified: i64 = -32801;
+
+// The client has canceled a request and a server as detected
+// the cancel.
+pub const RequestCancelled: i64 = -32800;
+
+// This is the end range of LSP reserved error codes.
+// It doesn't denote a real error code.
+//
+// @since 3.16.0
+pub const lspReservedErrorRangeEnd: i64 = -32800;

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -6,7 +6,7 @@
 // It doesn't denote a real error code.
 //
 // @since 3.16.0
-pub const lspReservedErrorRangeStart: i64 = -32899;
+pub const LSP_RESERVED_ERROR_RANGE_START: i64 = -32899;
 
 // The server cancelled the request. This error code should
 // only be used for requests that explicitly support being
@@ -14,8 +14,8 @@ pub const lspReservedErrorRangeStart: i64 = -32899;
 //
 // @since 3.17.0
 #[cfg(feature = "proposed")]
-pub const ServerCancelled: i64 = -32802;
- 
+pub const SERVER_CANCELLED: i64 = -32802;
+
 // The server detected that the content of a document got
 // modified outside normal conditions. A server should
 // NOT send this error code if it detects a content change
@@ -24,14 +24,14 @@ pub const ServerCancelled: i64 = -32802;
 //
 // If a client decides that a result is not of any use anymore
 // the client should cancel the request.
-pub const ContentModified: i64 = -32801;
+pub const CONTENT_MODIFIED: i64 = -32801;
 
 // The client has canceled a request and a server as detected
 // the cancel.
-pub const RequestCancelled: i64 = -32800;
+pub const REQUEST_CANCELLED: i64 = -32800;
 
 // This is the end range of LSP reserved error codes.
 // It doesn't denote a real error code.
 //
 // @since 3.16.0
-pub const lspReservedErrorRangeEnd: i64 = -32800;
+pub const LSP_RESERVED_ERROR_RANGE_END: i64 = -32800;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ use serde::de;
 use serde::de::Error as Error_;
 use serde_json::Value;
 
+pub mod error_codes;
 pub mod notification;
 pub mod request;
 


### PR DESCRIPTION
This pull request adds constants for LSP specific [error codes](https://microsoft.github.io/language-server-protocol/specifications//specification-3-17/#errorCodes), but not for the ones that are part of the JSON RPC specification.

I can add the JSON RPC ones mentioned in the LSP specification if you think that is appropriate?