### PR TITLE
Allow to deserialize enums from their string representation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,18 @@ macro_rules! lsp_enum {
                 }
             }
         }
+
+        impl std::convert::TryFrom<&String> for $typ {
+            type Error = &'static str;
+            fn try_from(value: &String) -> Result<Self, Self::Error> {
+                match value {
+                    $(
+                        _ if *value == format!("{:?}", Self::$name) => Ok(Self::$name),
+                    )*
+                    _ => Err("unknown enum variant"),
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Enums are normally serialized as integers, but in some parts of
kak-lsp we like to use strings.
I'm working on a feature to select specific kinds of symbols.
The editor support script wants to send something like ["Function",
"Method"], which I want to deserialize into SymbolKinds.

Add an implementation of TryFrom<&String> for enums. This is the dual
of the Debug.

An alternative solution would be to allow clients to enumerate all
enum variants, is there a way to do that?

I initially tried to implement TryFrom<&str> but got weird errors
when the input string does not have static lifetime, like

	SymbolKind::try_from(&("Function".to_string()))

	   Compiling lsp-types v0.91.1 (/home/johannes/git/lsp-types)
	   Compiling kak-lsp v11.0.1-snapshot (/home/johannes/git/kak-lsp)
	error[E0277]: the trait bound `lsp_types::SymbolKind: From<&std::string::String>` is not satisfied
	   --> src/language_features/document_symbol.rs:169:25
	    |
	169 |         SymbolKind::try_from(&("Function".to_string()))
	    |         ^^^^^^^^^^^^^^^^^^^^ the trait `From<&std::string::String>` is not implemented for `lsp_types::SymbolKind`
	    |
	    = note: required because of the requirements on the impl of `Into<lsp_types::SymbolKind>` for `&std::string::String`
	    = note: required because of the requirements on the impl of `TryFrom<&std::string::String>` for `lsp_types::SymbolKind`
	note: required by `try_from`
	   --> /home/johannes/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:477:5
	    |
	477 |     fn try_from(value: T) -> Result<Self, Self::Error>;
	    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

	error[E0277]: the trait bound `lsp_types::SymbolKind: From<&std::string::String>` is not satisfied
	   --> src/language_features/document_symbol.rs:169:25
	    |
	169 |         SymbolKind::try_from(&("Function".to_string()))
	    |         ^^^^^^^^^^^^^^^^^^^^ the trait `From<&std::string::String>` is not implemented for `lsp_types::SymbolKind`
	    |
	    = note: required because of the requirements on the impl of `Into<lsp_types::SymbolKind>` for `&std::string::String`
	    = note: required because of the requirements on the impl of `TryFrom<&std::string::String>` for `lsp_types::SymbolKind`
