### PR TITLE
Add "lsif" to keywords.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/lsp-types"
 
 readme = "README.md"
 
-keywords = ["language", "server", "lsp", "vscode"]
+keywords = ["language", "server", "lsp", "vscode", "lsif"]
 
 license = "MIT"
 


### PR DESCRIPTION
This crate is more complete and better maintained than any of the crates with "lsif" in their name but it doesn't show up in a crates.io search for "lsif". This should fix that.