### PR TITLE
Notebook additions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1665,6 +1665,41 @@ pub struct TextDocumentSyncOptions {
     pub save: Option<TextDocumentSyncSaveOptions>,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentSelector {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notebook_document_filter: NotebookDocumentFilter,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cell_selector: Option<Language>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentSyncOptions {
+    /// Open and close notifications are sent to the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notebook_document_selector: Option<NotebookDocumentSelector>,
+
+    /// Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+    /// and TextDocumentSyncKindIncremental.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change: Option<TextDocumentSyncKind>,
+
+    /// Will save notifications are sent to the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub will_save: Option<bool>,
+
+    /// Will save wait until requests are sent to the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub will_save_wait_until: Option<bool>,
+
+    /// Save notifications are sent to the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save: Option<TextDocumentSyncSaveOptions>,
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum OneOf<A, B> {


### PR DESCRIPTION
See upcoming LSP addition for Notebook documents:

[LSP Notebook Proposal](https://github.com/microsoft/vscode-languageserver-node/blob/815cb9737e8a0f5d9ef7e41dce42f6b771ca24aa/protocol/src/common/proposed.notebooks.md#notebooks)

This is a draft for adding notebooks to the spec, see VS Code notebook extension that uses Rust:
[Codebook](https://marketplace.visualstudio.com/items?itemName=codebook.codebook)

Using `rust-analyzer` works with a single cell in the notebook after hacking with the client and server code, this is the first step to add official notebook support for `rust-analyzer` to create a proper implementation.