### PR TITLE
feat: implement json helpers

### DIFF
--- a/src/inlay_hint.rs
+++ b/src/inlay_hint.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "proposed")]
 
 use crate::{
-    Command, Location, MarkupContent, Position, Range, StaticRegistrationOptions,
+    Command, LSPAny, Location, MarkupContent, Position, Range, StaticRegistrationOptions,
     TextDocumentIdentifier, TextDocumentRegistrationOptions, TextEdit, WorkDoneProgressOptions,
     WorkDoneProgressParams,
 };
@@ -131,11 +131,11 @@ pub struct InlayHint {
     /// to visually align/separate an inlay hint.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub padding_right: Option<bool>,
-    // FIXME(sno2): add [`data`] field after [`LSPAny`] is implemented
-    // /// A data entry field that is preserved on a inlay hint between
-    // /// a `textDocument/inlayHint` and a `inlayHint/resolve` request.
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub data: Option<crate::LSPAny>,
+
+    /// A data entry field that is preserved on a inlay hint between
+    /// a `textDocument/inlayHint` and a `inlayHint/resolve` request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<LSPAny>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1271,7 +1271,6 @@ pub struct WorkspaceClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_operations: Option<WorkspaceFileOperationsClientCapabilities>,
 
-
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "proposed")]
     pub inlay_hint: Option<InlayHintWorkspaceClientCapabilities>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,24 @@ pub struct CancelParams {
 
 /* ----------------- Basic JSON Structures ----------------- */
 
+/// The LSP any type
+///
+/// @since 3.17.0
+#[cfg(feature = "proposed")]
+pub type LSPAny = serde_json::Value;
+
+/// LSP object definition.
+///
+/// @since 3.17.0
+#[cfg(feature = "proposed")]
+pub type LSPObject = serde_json::Map<String, serde_json::Value>;
+
+/// LSP arrays.
+///
+/// @since 3.17.0
+#[cfg(feature = "proposed")]
+pub type LSPArray = Vec<serde_json::Value>;
+
 /// Position in a text document expressed as zero-based line and character offset.
 /// A position is between two characters like an 'insert' cursor in a editor.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default, Deserialize, Serialize)]
@@ -1255,8 +1273,8 @@ pub struct WorkspaceClientCapabilities {
 
 
     #[serde(skip_serializing_if = "Option::is_none")]
-		#[cfg(feature = "proposed")]
-		pub inlay_hint: Option<InlayHintWorkspaceClientCapabilities>,
+    #[cfg(feature = "proposed")]
+    pub inlay_hint: Option<InlayHintWorkspaceClientCapabilities>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]


### PR DESCRIPTION
Closes #232 and updates the `inlayHint` code to support the `data` property.  #231 must be merged first.