### PR TITLE
Add missing $/setTrace and $/logTrace notifications

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,9 @@ pub use workspace_symbols::*;
 
 pub mod lsif;
 
+mod trace;
+pub use trace::*;
+
 /* ----------------- Auxiliary types ----------------- */
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
@@ -1014,7 +1017,7 @@ pub struct InitializeParams {
     /// The initial trace setting. If omitted trace is disabled ('off').
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trace: Option<TraceOption>,
+    pub trace: Option<TraceValue>,
 
     /// The workspace folders configured in the client when the server starts.
     /// This property is only available if the client supports workspace folders.
@@ -1050,22 +1053,6 @@ pub struct ClientInfo {
 
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize, Serialize)]
 pub struct InitializedParams {}
-
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
-pub enum TraceOption {
-    #[serde(rename = "off")]
-    Off,
-    #[serde(rename = "messages")]
-    Messages,
-    #[serde(rename = "verbose")]
-    Verbose,
-}
-
-impl Default for TraceOption {
-    fn default() -> TraceOption {
-        TraceOption::Off
-    }
-}
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct GenericRegistrationOptions {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -12,6 +12,12 @@ macro_rules! lsp_notification {
     ("$/cancelRequest") => {
         $crate::notification::Cancel
     };
+    ("$/setTrace") => {
+        $crate::notification::SetTrace
+    };
+    ("$/logTrace") => {
+        $crate::notification::LogTrace
+    };
     ("initialized") => {
         $crate::notification::Initialized
     };
@@ -87,6 +93,29 @@ pub enum Cancel {}
 impl Notification for Cancel {
     type Params = CancelParams;
     const METHOD: &'static str = "$/cancelRequest";
+}
+
+/// A notification that should be used by the client to modify the trace
+/// setting of the server.
+#[derive(Debug)]
+pub enum SetTrace {}
+
+impl Notification for SetTrace {
+    type Params = SetTraceParams;
+    const METHOD: &'static str = "$/setTrace";
+}
+
+/// A notification to log the trace of the server’s execution.
+/// The amount and content of these notifications depends on the current trace configuration.
+///
+/// `LogTrace` should be used for systematic trace reporting. For single debugging messages,
+/// the server should send `LogMessage` notifications.
+#[derive(Debug)]
+pub enum LogTrace {}
+
+impl Notification for LogTrace {
+    type Params = LogTraceParams;
+    const METHOD: &'static str = "$/logTrace";
 }
 
 /// The initialized notification is sent from the client to the server after the client received
@@ -304,6 +333,8 @@ mod test {
     fn check_macro_definitions() {
         check_macro!("$/cancelRequest");
         check_macro!("$/progress");
+        check_macro!("$/logTrace");
+        check_macro!("$/setTrace");
         check_macro!("initialized");
         check_macro!("exit");
         check_macro!("window/showMessage");

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct SetTraceParams {
+    /// The new value that should be assigned to the trace setting.
+    pub value: TraceValue,
+}
+
+/// A TraceValue represents the level of verbosity with which the server systematically
+/// reports its execution trace using `LogTrace` notifications.
+///
+/// The initial trace value is set by the client at initialization and can be modified
+/// later using the `SetTrace` notification.
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TraceValue {
+    /// The server should not send any `$/logTrace` notification
+    Off,
+    /// The server should not add the 'verbose' field in the `LogTraceParams`
+    Messages,
+    Verbose,
+}
+
+impl Default for TraceValue {
+    fn default() -> TraceValue {
+        TraceValue::Off
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogTraceParams {
+    /// The message to be logged.
+    pub message: String,
+    /// Additional information that can be computed if the `trace` configuration
+    /// is set to `'verbose'`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verbose: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::test_serialization;
+
+    #[test]
+    fn test_set_trace_params() {
+        test_serialization(
+            &SetTraceParams {
+                value: TraceValue::Off,
+            },
+            r#"{"value":"off"}"#,
+        );
+    }
+
+    #[test]
+    fn test_log_trace_params() {
+        test_serialization(
+            &LogTraceParams {
+                message: "message".into(),
+                verbose: None,
+            },
+            r#"{"message":"message"}"#,
+        );
+
+        test_serialization(
+            &LogTraceParams {
+                message: "message".into(),
+                verbose: Some("verbose".into()),
+            },
+            r#"{"message":"message","verbose":"verbose"}"#,
+        );
+    }
+
+    #[test]
+    fn test_trace_value() {
+        test_serialization(
+            &vec![TraceValue::Off, TraceValue::Messages, TraceValue::Verbose],
+            r#"["off","messages","verbose"]"#,
+        );
+    }
+}


### PR DESCRIPTION
This adds types for the two missing notifications. See:
* https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#setTrace
* https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#logTrace

It also renames the `TraceOption` type to `TraceValue`, which is the name used in the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue).

Closes #235