### PR TITLE
Add Default derive for `InitializeParams`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -985,7 +985,7 @@ pub type DocumentSelector = Vec<DocumentFilter>;
 
 // ========================= Actual Protocol =========================
 
-#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeParams {
     /// The process Id of the parent process that started


### PR DESCRIPTION
Add Default to the derive for `InitializeParams` so that this struct
can be initialized without compilation warnings / errors about the
deprecated root_path field.

Tested by building something that errored on deprecated fields,
and using this code:

```
let capabilities = ClientCapabilities {
    ..Default::default()
};
let _init = InitializeParams {
    process_id: None,
    root_path: None,
    root_uri: None,
    initialization_options: None,
    capabilities,
    trace: None,
    workspace_folders: None,
    client_info: None,
    locale: None,
};
```

It did not error after adding the derive and changing to:

```
let capabilities = ClientCapabilities {
    ..Default::default()
};
let _init = InitializeParams {
    capabilities,
    ..Default::default()
};
```