### PR TITLE
Derive Hash for file change events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2256,7 +2256,7 @@ pub struct DidChangeWatchedFilesParams {
 }
 
 /// The file event type.
-#[derive(Eq, PartialEq, Copy, Clone, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Hash, Copy, Clone, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct FileChangeType(i32);
 lsp_enum! {
@@ -2273,7 +2273,7 @@ impl FileChangeType {
 }
 
 /// An event describing a file change.
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
 pub struct FileEvent {
     /// The file's URI.
     pub uri: Url,


### PR DESCRIPTION
I want to use it [here] for implementing
"workspace/didChangeWatchedFiles", specifically to deduplicate file
change events before I send them to the language server.

[here]: https://github.com/kak-lsp/kak-lsp/pull/650/commits/346123f52fc8a1e450ac522938aac6809f177a0f#diff-1fd48ab302efbb91fe84507671007262db18094467e4ad707d036f60ff22e0eaR92
