### PR TITLE
Support all new 3.17 features (except for notebooks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Proposed 3.17 features can be activated using the `proposed` feature flag.
 
 ## Links
 
-[Stable Protocol reference](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md)
+[Stable Protocol reference](https://github.com/microsoft/language-server-protocol/tree/gh-pages/_specifications/lsp/3.17/specification.md)
 
-[Proposed Protocol reference](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/lsp/3.17/specification.md)
+[Proposed Protocol reference](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/lsp/3.18/specification.md)

--- a/src/code_action.rs
+++ b/src/code_action.rs
@@ -294,9 +294,29 @@ pub struct CodeActionDisabled {
     pub reason: String,
 }
 
+/// The reason why code actions were requested.
+///
+/// @since 3.17.0
+#[derive(Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct CodeActionTriggerKind(i32);
+lsp_enum! {
+impl CodeActionTriggerKind {
+    /// Code actions were explicitly requested by the user or by an extension.
+    pub const INVOKED: CodeActionTriggerKind = CodeActionTriggerKind(1);
+
+    /// Code actions were requested automatically.
+    ///
+    /// This typically happens when current selection in a file changes, but can
+    /// also be triggered when file content changes.
+    pub const AUTOMATIC: CodeActionTriggerKind = CodeActionTriggerKind(2);
+}
+}
+
 /// Contains additional diagnostic information about the context in which
 /// a code action is run.
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeActionContext {
     /// An array of diagnostics.
     pub diagnostics: Vec<Diagnostic>,
@@ -307,6 +327,12 @@ pub struct CodeActionContext {
     /// can omit computing them.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub only: Option<Vec<CodeActionKind>>,
+
+    /// The reason why code actions were requested.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_kind: Option<CodeActionTriggerKind>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/code_action.rs
+++ b/src/code_action.rs
@@ -203,6 +203,15 @@ impl CodeActionKind {
     pub const SOURCE_ORGANIZE_IMPORTS: CodeActionKind =
         CodeActionKind::new("source.organizeImports");
 
+    /// Base kind for a 'fix all' source action: `source.fixAll`.
+    ///
+    /// 'Fix all' actions automatically fix errors that have a clear fix that
+    /// do not require user input. They should not suppress errors or perform
+    /// unsafe fixes such as generating new types or classes.
+    ///
+    /// @since 3.17.0
+    pub const SOURCE_FIX_ALL: CodeActionKind = CodeActionKind::new("source.fixAll");
+
     pub const fn new(tag: &'static str) -> Self {
         CodeActionKind(Cow::Borrowed(tag))
     }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -214,7 +214,6 @@ pub struct CompletionClientCapabilities {
     /// `insertTextMode` property.
     ///
     /// @since 3.17.0
-    #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_text_mode: Option<InsertTextMode>,
 }
@@ -463,9 +462,11 @@ pub struct CompletionItem {
     pub insert_text_format: Option<InsertTextFormat>,
 
     /// How whitespace and indentation is handled during completion
-    /// item insertion. If not provided the client's default value is used.
+    /// item insertion. If not provided the client's default value depends on
+    /// the `textDocument.completion.insertTextMode` client capability.
     ///
     /// @since 3.16.0
+    /// @since 3.17.0 - support for `textDocument.completion.insertTextMode`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_text_mode: Option<InsertTextMode>,
 

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -192,6 +192,21 @@ pub struct CompletionItemKindCapability {
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct CompletionListCapability {
+    /// The client supports the following itemDefaults on
+    /// a completion list.
+    ///
+    /// The value lists the supported property names of the
+    /// `CompletionList.itemDefaults` object. If omitted
+    /// no properties are supported.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_defaults: Option<Vec<String>>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompletionClientCapabilities {
     /// Whether completion supports dynamic registration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -216,6 +231,13 @@ pub struct CompletionClientCapabilities {
     /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_text_mode: Option<InsertTextMode>,
+
+    /// The client supports the following `CompletionList` specific
+    /// capabilities.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_list: Option<CompletionListCapability>,
 }
 
 /// A special text edit to provide an insert and a replace operation.

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -121,9 +121,7 @@ pub struct CompletionItemCapability {
     /// The client has support for completion item label
     /// details (see also `CompletionItemLabelDetails`).
     ///
-    /// @since 3.17.0 - proposed state
-    ///
-    #[cfg(feature = "proposed")]
+    /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label_details_support: Option<bool>,
 }
@@ -295,13 +293,11 @@ pub struct CompletionOptions {
     /// The server supports the following `CompletionItem` specific
     /// capabilities.
     ///
-    /// @since 3.17.0 - proposed state
-    #[cfg(feature = "proposed")]
+    /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completion_item: Option<CompletionOptionsCompletionItem>,
 }
 
-#[cfg(feature = "proposed")]
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionOptionsCompletionItem {
@@ -309,7 +305,7 @@ pub struct CompletionOptionsCompletionItem {
     /// details (see also `CompletionItemLabelDetails`) when receiving
     /// a completion item in a resolve call.
     ///
-    /// @since 3.17.0 - proposed state
+    /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label_details_support: Option<bool>,
 }
@@ -407,9 +403,7 @@ pub struct CompletionItem {
 
     /// Additional details for the label
     ///
-    /// @since 3.17.0 - proposed state
-    ///
-    #[cfg(feature = "proposed")]
+    /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label_details: Option<CompletionItemLabelDetails>,
 
@@ -537,8 +531,7 @@ impl CompletionItem {
 
 /// Additional details for a completion item label.
 ///
-/// @since 3.17.0 - proposed state
-#[cfg(feature = "proposed")]
+/// @since 3.17.0
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionItemLabelDetails {

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -13,7 +13,6 @@ pub const LSP_RESERVED_ERROR_RANGE_START: i64 = -32899;
 // server cancellable.
 //
 // @since 3.17.0
-#[cfg(feature = "proposed")]
 pub const SERVER_CANCELLED: i64 = -32802;
 
 // The server detected that the content of a document got

--- a/src/folding_range.rs
+++ b/src/folding_range.rs
@@ -47,6 +47,28 @@ pub struct FoldingProviderOptions {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct FoldingRangeKindCapability {
+    /// The folding range kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_set: Option<Vec<FoldingRangeKind>>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FoldingRangeCapability {
+    /// If set, the client signals that it supports setting collapsedText on
+    /// folding ranges to display custom labels instead of the default text.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collapsed_text: Option<bool>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FoldingRangeClientCapabilities {
     /// Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
     /// the client supports the new `(FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
@@ -58,10 +80,22 @@ pub struct FoldingRangeClientCapabilities {
     /// hint, servers are free to follow the limit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub range_limit: Option<u32>,
+
     /// If set, the client signals that it only supports folding complete lines. If set, client will
     /// ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_folding_only: Option<bool>,
+
+    /// Specific options for the folding range kind.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub folding_range_kind: Option<FoldingRangeKindCapability>,
+
+    /// Specific options for the folding range.
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub folding_range: Option<FoldingRangeCapability>,
 }
 
 /// Enum of known range kinds
@@ -99,4 +133,12 @@ pub struct FoldingRange {
     /// [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<FoldingRangeKind>,
+
+    /// The text that the client should show when the specified range is
+    /// collapsed. If not defined or not supported by the client, a default
+    /// will be chosen by the client.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collapsed_text: Option<String>,
 }

--- a/src/inlay_hint.rs
+++ b/src/inlay_hint.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "proposed")]
-
 use crate::{
     Command, LSPAny, Location, MarkupContent, Position, Range, StaticRegistrationOptions,
     TextDocumentIdentifier, TextDocumentRegistrationOptions, TextEdit, WorkDoneProgressOptions,
@@ -17,7 +15,7 @@ pub enum InlayHintServerCapabilities {
 
 /// Inlay hint client capabilities.
 ///
-/// @since 3.17.0 - proposed state
+/// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintClientCapabilities {
@@ -33,7 +31,7 @@ pub struct InlayHintClientCapabilities {
 
 /// Inlay hint options used during static registration.
 ///
-/// @since 3.17.0 - proposed state
+/// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintOptions {
@@ -48,7 +46,7 @@ pub struct InlayHintOptions {
 
 /// Inlay hint options used during static or dynamic registration.
 ///
-/// @since 3.17.0 - proposed state
+/// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintRegistrationOptions {
@@ -64,7 +62,7 @@ pub struct InlayHintRegistrationOptions {
 
 /// A parameter literal used in inlay hint requests.
 ///
-/// @since 3.17.0 - proposed state
+/// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintParams {
@@ -80,7 +78,7 @@ pub struct InlayHintParams {
 
 /// Inlay hint information.
 ///
-/// @since 3.17.0 - proposed state
+/// @since 3.17.0
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHint {
@@ -239,7 +237,7 @@ impl From<MarkupContent> for InlayHintLabelPartTooltip {
 
 /// Inlay hint kinds.
 ///
-/// @since 3.17.0 - proposed state
+/// @since 3.17.0
 #[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct InlayHintKind(i32);
@@ -253,15 +251,19 @@ impl InlayHintKind {
 }
 }
 
+/// Inlay hint client capabilities.
+///
+/// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintResolveClientCapabilities {
+    /// The properties that a client can resolve lazily.
     pub properties: Vec<String>,
 }
 
 /// Client workspace capabilities specific to inlay hints.
 ///
-/// @since 3.17.0 - proposed state
+/// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintWorkspaceClientCapabilities {

--- a/src/inline_value.rs
+++ b/src/inline_value.rs
@@ -1,0 +1,217 @@
+use crate::{
+    DynamicRegistrationClientCapabilities, Range, StaticRegistrationOptions,
+    TextDocumentIdentifier, TextDocumentRegistrationOptions, WorkDoneProgressOptions,
+    WorkDoneProgressParams,
+};
+use serde::{Deserialize, Serialize};
+
+pub type InlineValueClientCapabilities = DynamicRegistrationClientCapabilities;
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum InlineValueServerCapabilities {
+    Options(InlineValueOptions),
+    RegistrationOptions(InlineValueRegistrationOptions),
+}
+
+/// Inline value options used during static registration.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct InlineValueOptions {
+    #[serde(flatten)]
+    pub work_done_progress_options: WorkDoneProgressOptions,
+}
+
+/// Inline value options used during static or dynamic registration.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct InlineValueRegistrationOptions {
+    #[serde(flatten)]
+    pub inline_value_options: InlineValueOptions,
+
+    #[serde(flatten)]
+    pub text_document_registration_options: TextDocumentRegistrationOptions,
+
+    #[serde(flatten)]
+    pub static_registration_options: StaticRegistrationOptions,
+}
+
+/// A parameter literal used in inline value requests.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlineValueParams {
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
+
+    /// The text document.
+    pub text_document: TextDocumentIdentifier,
+
+    /// The document range for which inline values should be computed.
+    pub range: Range,
+
+    /// Additional information about the context in which inline values were
+    /// requested.
+    pub context: InlineValueContext,
+}
+
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlineValueContext {
+    /// The stack frame (as a DAP Id) where the execution has stopped.
+    pub frame_id: i32,
+
+    /// The document range where execution has stopped.
+    /// Typically the end position of the range denotes the line where the
+    /// inline values are shown.
+    pub stopped_location: Range,
+}
+
+/// Provide inline value as text.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct InlineValueText {
+    /// The document range for which the inline value applies.
+    pub range: Range,
+
+    /// The text of the inline value.
+    pub text: String,
+}
+
+/// Provide inline value through a variable lookup.
+///
+/// If only a range is specified, the variable name will be extracted from
+/// the underlying document.
+///
+/// An optional variable name can be used to override the extracted name.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlineValueVariableLookup {
+    /// The document range for which the inline value applies.
+    /// The range is used to extract the variable name from the underlying
+    /// document.
+    pub range: Range,
+
+    /// If specified the name of the variable to look up.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variable_name: Option<String>,
+
+    /// How to perform the lookup.
+    pub case_sensitive_lookup: bool,
+}
+
+/// Provide an inline value through an expression evaluation.
+///
+/// If only a range is specified, the expression will be extracted from the
+/// underlying document.
+///
+/// An optional expression can be used to override the extracted expression.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlineValueEvaluatableExpression {
+    /// The document range for which the inline value applies.
+    /// The range is used to extract the evaluatable expression from the
+    /// underlying document.
+    pub range: Range,
+
+    /// If specified the expression overrides the extracted expression.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+}
+
+/// Inline value information can be provided by different means:
+/// - directly as a text value (class InlineValueText).
+/// - as a name to use for a variable lookup (class InlineValueVariableLookup)
+/// - as an evaluatable expression (class InlineValueEvaluatableExpression)
+/// The InlineValue types combines all inline value types into one type.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum InlineValue {
+    Text(InlineValueText),
+    VariableLookup(InlineValueVariableLookup),
+    EvaluatableExpression(InlineValueEvaluatableExpression),
+}
+
+impl From<InlineValueText> for InlineValue {
+    #[inline]
+    fn from(from: InlineValueText) -> Self {
+        Self::Text(from)
+    }
+}
+
+impl From<InlineValueVariableLookup> for InlineValue {
+    #[inline]
+    fn from(from: InlineValueVariableLookup) -> Self {
+        Self::VariableLookup(from)
+    }
+}
+
+impl From<InlineValueEvaluatableExpression> for InlineValue {
+    #[inline]
+    fn from(from: InlineValueEvaluatableExpression) -> Self {
+        Self::EvaluatableExpression(from)
+    }
+}
+
+/// Client workspace capabilities specific to inline values.
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+///
+/// @since 3.17.0
+#[serde(rename_all = "camelCase")]
+pub struct InlineValueWorkspaceClientCapabilities {
+    /// Whether the client implementation supports a refresh request sent from
+    /// the server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// inline values currently shown. It should be used with absolute care and
+    /// is useful for situation where a server for example detect a project wide
+    /// change that requires such a calculation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_support: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::test_serialization;
+    use crate::Position;
+
+    #[test]
+    fn inline_values() {
+        test_serialization(
+            &InlineValueText {
+                range: Range::new(Position::new(0, 0), Position::new(0, 4)),
+                text: "one".to_owned(),
+            },
+            r#"{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":4}},"text":"one"}"#,
+        );
+
+        test_serialization(
+            &InlineValue::VariableLookup(InlineValueVariableLookup {
+                range: Range::new(Position::new(1, 0), Position::new(1, 4)),
+                variable_name: None,
+                case_sensitive_lookup: false,
+            }),
+            r#"{"range":{"start":{"line":1,"character":0},"end":{"line":1,"character":4}},"caseSensitiveLookup":false}"#,
+        );
+
+        test_serialization(
+            &InlineValue::EvaluatableExpression(InlineValueEvaluatableExpression {
+                range: Range::new(Position::new(2, 0), Position::new(2, 4)),
+                expression: None,
+            }),
+            r#"{"range":{"start":{"line":2,"character":0},"end":{"line":2,"character":4}}}"#,
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@ pub use hover::*;
 mod inlay_hint;
 pub use inlay_hint::*;
 
+mod inline_value;
+pub use inline_value::*;
+
 mod moniker;
 pub use moniker::*;
 
@@ -1302,6 +1305,11 @@ pub struct WorkspaceClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_operations: Option<WorkspaceFileOperationsClientCapabilities>,
 
+    /// Client workspace capabilities specific to inline values.
+    /// since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_value: Option<InlineValueWorkspaceClientCapabilities>,
+
     /// Client workspace capabilities specific to inlay hints.
     /// since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1510,6 +1518,12 @@ pub struct TextDocumentClientCapabilities {
     /// @since 3.16.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub moniker: Option<MonikerClientCapabilities>,
+
+    /// Capabilities specific to the `textDocument/inlineValue` request.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_value: Option<InlineValueClientCapabilities>,
 
     /// Capabilities specific to the `textDocument/inlayHint` request.
     ///
@@ -1939,6 +1953,12 @@ pub struct ServerCapabilities {
     /// Whether server provides moniker support.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub moniker_provider: Option<OneOf<bool, MonikerServerCapabilities>>,
+
+    /// The server provides inline values.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_value_provider: Option<OneOf<bool, InlineValueServerCapabilities>>,
 
     /// The server provides inlay hints.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2115,6 +2115,13 @@ pub struct DocumentHighlightOptions {
 pub struct WorkspaceSymbolOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
+
+    /// The server provides support to resolve additional
+    /// information for a workspace symbol.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolve_provider: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,9 +144,7 @@ pub use formatting::*;
 mod hover;
 pub use hover::*;
 
-#[cfg(feature = "proposed")]
 mod inlay_hint;
-#[cfg(feature = "proposed")]
 pub use inlay_hint::*;
 
 mod moniker;
@@ -1304,8 +1302,9 @@ pub struct WorkspaceClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_operations: Option<WorkspaceFileOperationsClientCapabilities>,
 
+    /// Client workspace capabilities specific to inlay hints.
+    /// since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg(feature = "proposed")]
     pub inlay_hint: Option<InlayHintWorkspaceClientCapabilities>,
 }
 
@@ -1514,9 +1513,8 @@ pub struct TextDocumentClientCapabilities {
 
     /// Capabilities specific to the `textDocument/inlayHint` request.
     ///
-    /// @since 3.17.0 - proposed state
+    /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg(feature = "proposed")]
     pub inlay_hint: Option<InlayHintClientCapabilities>,
 }
 
@@ -1944,9 +1942,8 @@ pub struct ServerCapabilities {
 
     /// The server provides inlay hints.
     ///
-    /// @since 3.17.0 - proposed state
+    /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg(feature = "proposed")]
     pub inlay_hint_provider: Option<OneOf<bool, InlayHintServerCapabilities>>,
 
     /// The server provides linked editing range support.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1582,8 +1582,10 @@ pub struct GeneralClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub markdown: Option<MarkdownClientCapabilities>,
 
+    /// Client capability that signals how the client handles stale requests (e.g. a request for
+    /// which the client will not process the response anymore since the information is outdated).
+    ///
     /// @since 3.17.0
-    #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stale_request_support: Option<StaleRequestSupportClientCapabilities>,
 
@@ -1615,7 +1617,6 @@ pub struct GeneralClientCapabilities {
 /// anymore since the information is outdated).
 ///
 /// @since 3.17.0
-#[cfg(feature = "proposed")]
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StaleRequestSupportClientCapabilities {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,10 +297,8 @@ pub struct LocationLink {
 ///
 /// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
-#[cfg(feature = "proposed")]
 pub struct PositionEncodingKind(std::borrow::Cow<'static, str>);
 
-#[cfg(feature = "proposed")]
 impl PositionEncodingKind {
     /// Character offsets count UTF-8 code units.
     pub const UTF8: PositionEncodingKind = PositionEncodingKind::new("utf-8");
@@ -327,14 +325,12 @@ impl PositionEncodingKind {
     }
 }
 
-#[cfg(feature = "proposed")]
 impl From<String> for PositionEncodingKind {
     fn from(from: String) -> Self {
         PositionEncodingKind(std::borrow::Cow::from(from))
     }
 }
 
-#[cfg(feature = "proposed")]
 impl From<&'static str> for PositionEncodingKind {
     fn from(from: &'static str) -> Self {
         PositionEncodingKind::new(from)
@@ -1600,7 +1596,6 @@ pub struct GeneralClientCapabilities {
     /// side.
     ///
     /// @since 3.17.0
-    #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position_encodings: Option<Vec<PositionEncodingKind>>,
 }
@@ -1850,7 +1845,6 @@ pub struct ServerCapabilities {
     ///
     /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg(feature = "proposed")]
     pub position_encoding: Option<PositionEncodingKind>,
 
     /// Defines how text documents are synced.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,19 +209,16 @@ pub struct CancelParams {
 /// The LSP any type
 ///
 /// @since 3.17.0
-#[cfg(feature = "proposed")]
 pub type LSPAny = serde_json::Value;
 
 /// LSP object definition.
 ///
 /// @since 3.17.0
-#[cfg(feature = "proposed")]
 pub type LSPObject = serde_json::Map<String, serde_json::Value>;
 
 /// LSP arrays.
 ///
 /// @since 3.17.0
-#[cfg(feature = "proposed")]
 pub type LSPArray = Vec<serde_json::Value>;
 
 /// Position in a text document expressed as zero-based line and character offset.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1644,6 +1644,13 @@ pub struct MarkdownClientCapabilities {
     /// The version of the parser.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+
+    /// A list of HTML tags that the client allows / supports in
+    /// Markdown.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_tags: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,9 @@ pub use semantic_tokens::*;
 mod signature_help;
 pub use signature_help::*;
 
+mod type_hierarchy;
+pub use type_hierarchy::*;
+
 mod linked_editing;
 pub use linked_editing::*;
 
@@ -1514,6 +1517,12 @@ pub struct TextDocumentClientCapabilities {
     /// @since 3.16.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub moniker: Option<MonikerClientCapabilities>,
+
+    /// Capabilities specific to the various type hierarchy requests.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub type_hierarchy: Option<TypeHierarchyClientCapabilities>,
 
     /// Capabilities specific to the `textDocument/inlineValue` request.
     ///

--- a/src/request.rs
+++ b/src/request.rs
@@ -153,6 +153,9 @@ macro_rules! lsp_request {
     ("textDocument/inlayHint") => {
         $crate::request::InlayHintRequest
     };
+    ("textDocument/inlineValue") => {
+        $crate::request::InlineValueRequest
+    };
     ("workspace/willCreateFiles") => {
         $crate::request::WillCreateFiles
     };
@@ -170,6 +173,9 @@ macro_rules! lsp_request {
     };
     ("workspace/inlayHint/refresh") => {
         $crate::request::InlayHintRefreshRequest
+    };
+    ("workspace/inlineValue/refresh") => {
+        $crate::request::InlineValueRefreshRequest
     };
     ("codeAction/resolve") => {
         $crate::request::CodeActionResolveRequest
@@ -816,6 +822,30 @@ impl Request for InlayHintRefreshRequest {
     const METHOD: &'static str = "workspace/inlayHint/refresh";
 }
 
+/// The inline value request is sent from the client to the server to compute inline values for a
+/// given text document that may be rendered in the editor at the end of lines.
+pub enum InlineValueRequest {}
+
+impl Request for InlineValueRequest {
+    type Params = InlineValueParams;
+    type Result = Option<InlineValue>;
+    const METHOD: &'static str = "textDocument/inlineValue";
+}
+
+/// The `workspace/inlineValue/refresh` request is sent from the server to the client. Servers can
+/// use it to ask clients to refresh the inline values currently shown in editors. As a result the
+/// client should ask the server to recompute the inline values for these editors. This is useful if
+/// a server detects a configuration change which requires a re-calculation of all inline values.
+/// Note that the client still has the freedom to delay the re-calculation of the inline values if
+/// for example an editor is currently not visible.
+pub enum InlineValueRefreshRequest {}
+
+impl Request for InlineValueRefreshRequest {
+    type Params = ();
+    type Result = ();
+    const METHOD: &'static str = "workspace/inlineValue/refresh";
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -879,6 +909,7 @@ mod test {
         check_macro!("textDocument/semanticTokens/full/delta");
         check_macro!("textDocument/semanticTokens/range");
         check_macro!("textDocument/inlayHint");
+        check_macro!("textDocument/inlineValue");
 
         check_macro!("workspace/applyEdit");
         check_macro!("workspace/symbol");
@@ -891,13 +922,14 @@ mod test {
         check_macro!("workspace/semanticTokens/refresh");
         check_macro!("workspace/codeLens/refresh");
         check_macro!("workspace/inlayHint/refresh");
+        check_macro!("workspace/inlineValue/refresh");
 
+        check_macro!("callHierarchy/incomingCalls");
+        check_macro!("callHierarchy/outgoingCalls");
         check_macro!("codeAction/resolve");
         check_macro!("codeLens/resolve");
         check_macro!("completionItem/resolve");
         check_macro!("documentLink/resolve");
-        check_macro!("callHierarchy/incomingCalls");
-        check_macro!("callHierarchy/outgoingCalls");
         check_macro!("inlayHint/resolve");
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,7 +29,7 @@ macro_rules! lsp_request {
     };
 
     ("workspace/symbol") => {
-        $crate::request::WorkspaceSymbol
+        $crate::request::WorkspaceSymbolRequest
     };
     ("workspace/executeCommand") => {
         $crate::request::ExecuteCommand
@@ -395,12 +395,23 @@ impl Request for DocumentSymbolRequest {
 /// The workspace symbol request is sent from the client to the server to list project-wide symbols
 /// matching the query string.
 #[derive(Debug)]
-pub enum WorkspaceSymbol {}
+pub enum WorkspaceSymbolRequest {}
 
-impl Request for WorkspaceSymbol {
+impl Request for WorkspaceSymbolRequest {
     type Params = WorkspaceSymbolParams;
-    type Result = Option<Vec<SymbolInformation>>;
+    type Result = Option<WorkspaceSymbolResponse>;
     const METHOD: &'static str = "workspace/symbol";
+}
+
+/// The `workspaceSymbol/resolve` request is sent from the client to the server to resolve
+/// additional information for a given workspace symbol.
+#[derive(Debug)]
+pub enum WorkspaceSymbolResolve {}
+
+impl Request for WorkspaceSymbolResolve {
+    type Params = WorkspaceSymbol;
+    type Result = WorkspaceSymbol;
+    const METHOD: &'static str = "workspaceSymbol/resolve";
 }
 
 /// The workspace/executeCommand request is sent from the client to the server to trigger command execution on the server.

--- a/src/request.rs
+++ b/src/request.rs
@@ -150,6 +150,9 @@ macro_rules! lsp_request {
     ("textDocument/semanticTokens/range") => {
         $crate::request::SemanticTokensRangeRequest
     };
+    ("textDocument/inlayHint") => {
+        $crate::request::InlayHintRequest
+    };
     ("workspace/willCreateFiles") => {
         $crate::request::WillCreateFiles
     };
@@ -165,8 +168,14 @@ macro_rules! lsp_request {
     ("workspace/codeLens/refresh") => {
         $crate::request::CodeLensRefresh
     };
+    ("workspace/inlayHint/refresh") => {
+        $crate::request::InlayHintRefreshRequest
+    };
     ("codeAction/resolve") => {
         $crate::request::CodeActionResolveRequest
+    };
+    ("inlayHint/resolve") => {
+        $crate::request::InlayHintResolveRequest
     };
     ("window/showDocument") => {
         $crate::request::ShowDocument
@@ -771,30 +780,36 @@ impl Request for MonikerRequest {
     const METHOD: &'static str = "textDocument/moniker";
 }
 
-#[cfg(feature = "proposed")]
+/// The inlay hints request is sent from the client to the server to compute inlay hints for a given
+/// [text document, range] tuple that may be rendered in the editor in place with other text.
 pub enum InlayHintRequest {}
 
-#[cfg(feature = "proposed")]
 impl Request for InlayHintRequest {
     type Params = InlayHintParams;
     type Result = Option<Vec<InlayHint>>;
     const METHOD: &'static str = "textDocument/inlayHint";
 }
 
-#[cfg(feature = "proposed")]
+/// The `inlayHint/resolve` request is sent from the client to the server to resolve additional
+/// information for a given inlay hint. This is usually used to compute the tooltip, location or
+/// command properties of a inlay hint’s label part to avoid its unnecessary computation during the
+/// `textDocument/inlayHint` request.
 pub enum InlayHintResolveRequest {}
 
-#[cfg(feature = "proposed")]
 impl Request for InlayHintResolveRequest {
     type Params = InlayHint;
     type Result = InlayHint;
     const METHOD: &'static str = "inlayHint/resolve";
 }
 
-#[cfg(feature = "proposed")]
+/// The `workspace/inlayHint/refresh` request is sent from the server to the client. Servers can use
+/// it to ask clients to refresh the inlay hints currently shown in editors. As a result the client
+/// should ask the server to recompute the inlay hints for these editors. This is useful if a server
+/// detects a configuration change which requires a re-calculation of all inlay hints. Note that the
+/// client still has the freedom to delay the re-calculation of the inlay hints if for example an
+/// editor is currently not visible.
 pub enum InlayHintRefreshRequest {}
 
-#[cfg(feature = "proposed")]
 impl Request for InlayHintRefreshRequest {
     type Params = ();
     type Result = ();
@@ -863,6 +878,7 @@ mod test {
         check_macro!("textDocument/semanticTokens/full");
         check_macro!("textDocument/semanticTokens/full/delta");
         check_macro!("textDocument/semanticTokens/range");
+        check_macro!("textDocument/inlayHint");
 
         check_macro!("workspace/applyEdit");
         check_macro!("workspace/symbol");
@@ -874,6 +890,7 @@ mod test {
         check_macro!("workspace/workspaceFolders");
         check_macro!("workspace/semanticTokens/refresh");
         check_macro!("workspace/codeLens/refresh");
+        check_macro!("workspace/inlayHint/refresh");
 
         check_macro!("codeAction/resolve");
         check_macro!("codeLens/resolve");
@@ -881,6 +898,7 @@ mod test {
         check_macro!("documentLink/resolve");
         check_macro!("callHierarchy/incomingCalls");
         check_macro!("callHierarchy/outgoingCalls");
+        check_macro!("inlayHint/resolve");
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -141,6 +141,9 @@ macro_rules! lsp_request {
     ("textDocument/prepareCallHierarchy") => {
         $crate::request::CallHierarchyPrepare
     };
+    ("textDocument/prepareTypeHierarchy") => {
+        $crate::request::TypeHierarchyPrepare
+    };
     ("textDocument/semanticTokens/full") => {
         $crate::request::SemanticTokensFullRequest
     };
@@ -155,6 +158,12 @@ macro_rules! lsp_request {
     };
     ("textDocument/inlineValue") => {
         $crate::request::InlineValueRequest
+    };
+    ("typeHierarchy/supertypes") => {
+        $crate::request::TypeHierarchySupertypes
+    };
+    ("typeHierarchy/subtypes") => {
+        $crate::request::TypeHierarchySubtypes
     };
     ("workspace/willCreateFiles") => {
         $crate::request::WillCreateFiles
@@ -857,6 +866,45 @@ impl Request for InlineValueRefreshRequest {
     const METHOD: &'static str = "workspace/inlineValue/refresh";
 }
 
+/// The type hierarchy request is sent from the client to the server to return a type hierarchy for
+/// the language element of given text document positions. Will return null if the server couldn’t
+/// infer a valid type from the position. The type hierarchy requests are executed in two steps:
+///
+/// 1. first a type hierarchy item is prepared for the given text document position.
+/// 2. for a type hierarchy item the supertype or subtype type hierarchy items are resolved.
+pub enum TypeHierarchyPrepare {}
+
+impl Request for TypeHierarchyPrepare {
+    type Params = TypeHierarchyPrepareParams;
+    type Result = Option<Vec<TypeHierarchyItem>>;
+    const METHOD: &'static str = "textDocument/prepareTypeHierarchy";
+}
+
+/// The `typeHierarchy/supertypes` request is sent from the client to the server to resolve the
+/// supertypes for a given type hierarchy item. Will return null if the server couldn’t infer a
+/// valid type from item in the params. The request doesn’t define its own client and server
+/// capabilities. It is only issued if a server registers for the
+/// `textDocument/prepareTypeHierarchy` request.
+pub enum TypeHierarchySupertypes {}
+
+impl Request for TypeHierarchySupertypes {
+    type Params = TypeHierarchySupertypesParams;
+    type Result = Option<Vec<TypeHierarchyItem>>;
+    const METHOD: &'static str = "typeHierarchy/supertypes";
+}
+
+/// The `typeHierarchy/subtypes` request is sent from the client to the server to resolve the
+/// subtypes for a given type hierarchy item. Will return null if the server couldn’t infer a valid
+/// type from item in the params. The request doesn’t define its own client and server capabilities.
+/// It is only issued if a server registers for the textDocument/prepareTypeHierarchy request.
+pub enum TypeHierarchySubtypes {}
+
+impl Request for TypeHierarchySubtypes {
+    type Params = TypeHierarchySubtypesParams;
+    type Result = Option<Vec<TypeHierarchyItem>>;
+    const METHOD: &'static str = "typeHierarchy/subtypes";
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -916,6 +964,7 @@ mod test {
         check_macro!("textDocument/moniker");
         check_macro!("textDocument/linkedEditingRange");
         check_macro!("textDocument/prepareCallHierarchy");
+        check_macro!("textDocument/prepareTypeHierarchy");
         check_macro!("textDocument/semanticTokens/full");
         check_macro!("textDocument/semanticTokens/full/delta");
         check_macro!("textDocument/semanticTokens/range");
@@ -942,6 +991,8 @@ mod test {
         check_macro!("completionItem/resolve");
         check_macro!("documentLink/resolve");
         check_macro!("inlayHint/resolve");
+        check_macro!("typeHierarchy/subtypes");
+        check_macro!("typeHierarchy/supertypes");
     }
 
     #[test]

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -39,7 +39,6 @@ impl SemanticTokenType {
     pub const OPERATOR: SemanticTokenType = SemanticTokenType::new("operator");
 
     /// since @3.17.0
-    #[cfg(feature = "proposed")]
     pub const DECORATOR: SemanticTokenType = SemanticTokenType::new("decorator");
 
     pub const fn new(tag: &'static str) -> Self {
@@ -142,9 +141,7 @@ pub struct SemanticTokensLegend {
     pub token_modifiers: Vec<SemanticTokenModifier>,
 }
 
-/// The actual tokens. For a detailed description about how the data is
-/// structured please see
-/// <https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71>
+/// The actual tokens.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
 pub struct SemanticToken {
     pub delta_line: u32,
@@ -375,10 +372,8 @@ pub struct SemanticTokensClientCapabilities {
     /// needs to retrigger the request.
     ///
     /// since @3.17.0
-    #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_cancel_support: Option<bool>,
-
 
     /// Whether the client uses semantic tokens to augment existing
     /// syntax tokens. If set to `true` client side created syntax
@@ -390,7 +385,6 @@ pub struct SemanticTokensClientCapabilities {
     /// specified.
     ///
     /// @since 3.17.0
-    #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub augments_syntax_tokens: Option<bool>,
 }

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -1,0 +1,90 @@
+use crate::{
+    DynamicRegistrationClientCapabilities, LSPAny, PartialResultParams, Range,
+    StaticRegistrationOptions, SymbolKind, SymbolTag, TextDocumentPositionParams,
+    TextDocumentRegistrationOptions, Url, WorkDoneProgressOptions, WorkDoneProgressParams,
+};
+
+use serde::{Deserialize, Serialize};
+
+pub type TypeHierarchyClientCapabilities = DynamicRegistrationClientCapabilities;
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct TypeHierarchyOptions {
+    #[serde(flatten)]
+    pub work_done_progress_options: WorkDoneProgressOptions,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct TypeHierarchyRegistrationOptions {
+    #[serde(flatten)]
+    pub text_document_registration_options: TextDocumentRegistrationOptions,
+    #[serde(flatten)]
+    pub type_hierarchy_options: TypeHierarchyOptions,
+    #[serde(flatten)]
+    pub static_registration_options: StaticRegistrationOptions,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct TypeHierarchyPrepareParams {
+    #[serde(flatten)]
+    pub text_document_position_params: TextDocumentPositionParams,
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct TypeHierarchySupertypesParams {
+    pub item: TypeHierarchyItem,
+
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
+    #[serde(flatten)]
+    pub partial_result_params: PartialResultParams,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct TypeHierarchySubtypesParams {
+    pub item: TypeHierarchyItem,
+
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
+    #[serde(flatten)]
+    pub partial_result_params: PartialResultParams,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeHierarchyItem {
+    /// The name of this item.
+    pub name: String,
+
+    /// The kind of this item.
+    pub kind: SymbolKind,
+
+    /// Tags for this item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<SymbolTag>,
+
+    /// More detail for this item, e.g. the signature of a function.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+
+    /// The resource identifier of this item.
+    pub uri: Url,
+
+    /// The range enclosing this symbol not including leading/trailing whitespace
+    /// but everything else, e.g. comments and code.
+    pub range: Range,
+
+    /// The range that should be selected and revealed when this symbol is being
+    /// picked, e.g. the name of a function. Must be contained by the
+    /// [`range`](#TypeHierarchyItem.range).
+    pub selection_range: Range,
+
+    /// A data entry field that is preserved between a type hierarchy prepare and
+    /// supertypes or subtypes requests. It could also be used to identify the
+    /// type hierarchy in the server, helping improve the performance on
+    /// resolving supertypes and subtypes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<LSPAny>,
+}

--- a/src/workspace_folders.rs
+++ b/src/workspace_folders.rs
@@ -21,7 +21,7 @@ pub struct WorkspaceFoldersServerCapabilities {
     pub change_notifications: Option<OneOf<bool, String>>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceFolder {
     /// The associated URI for this workspace folder.

--- a/src/workspace_symbols.rs
+++ b/src/workspace_symbols.rs
@@ -1,6 +1,7 @@
-use crate::{PartialResultParams, SymbolKindCapability, WorkDoneProgressParams};
-
-use crate::{SymbolTag, TagSupport};
+use crate::{
+    LSPAny, Location, OneOf, PartialResultParams, SymbolInformation, SymbolKind,
+    SymbolKindCapability, SymbolTag, TagSupport, Url, WorkDoneProgressParams,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -26,6 +27,14 @@ pub struct WorkspaceSymbolClientCapabilities {
         deserialize_with = "TagSupport::deserialize_compat"
     )]
     pub tag_support: Option<TagSupport<SymbolTag>>,
+
+    /// The client support partial workspace symbols. The client will send the
+    /// request `workspaceSymbol/resolve` to the server to resolve additional
+    /// properties.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolve_support: Option<WorkspaceSymbolResolveSupportCapability>,
 }
 
 /// The parameters of a Workspace Symbol Request.
@@ -39,4 +48,59 @@ pub struct WorkspaceSymbolParams {
 
     /// A non-empty query string
     pub query: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct WorkspaceSymbolResolveSupportCapability {
+    /// The properties that a client can resolve lazily. Usually
+    /// `location.range`
+    pub properties: Vec<String>,
+}
+
+/// A special workspace symbol that supports locations without a range
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSymbol {
+    /// The name of this symbol.
+    pub name: String,
+
+    /// The kind of this symbol.
+    pub kind: SymbolKind,
+
+    /// Tags for this completion item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<SymbolTag>>,
+
+    /// The name of the symbol containing this symbol. This information is for
+    /// user interface purposes (e.g. to render a qualifier in the user interface
+    /// if necessary). It can't be used to re-infer a hierarchy for the document
+    /// symbols.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
+
+    /// The location of this symbol. Whether a server is allowed to
+    /// return a location without a range depends on the client
+    /// capability `workspace.symbol.resolveSupport`.
+    ///
+    /// See also `SymbolInformation.location`.
+    pub location: OneOf<Location, WorkspaceLocation>,
+
+    /// A data entry field that is preserved on a workspace symbol between a
+    /// workspace symbol request and a workspace symbol resolve request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<LSPAny>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct WorkspaceLocation {
+    pub uri: Url,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceSymbolResponse {
+    Flat(Vec<SymbolInformation>),
+    Nested(Vec<WorkspaceSymbol>),
 }


### PR DESCRIPTION
### Added

* Add support for `textDocument/inlineValue`.
* Add new features to `workspace/symbols` and support `workspaceSymbol/resolve`.
* Add support for HTML tags in `MarkdownClientCapabilities`.
* Add support for collapsed text in folding.
* Add support for trigger kinds in code action requests.
* Add support for position encoding (not sure if safe to remove support for unofficial `UTF8-offsets` extension now?)
* Add support for relative patterns in `FileSystemWatcher`s
* Add support for type hierarchies.
* Stabilize `CodeActionKind::SOURCE_FIX_ALL`.

### Changed

* Stabilize `LSPAny`, `LSPObject`, and `LSPArray` type aliases.
* Stabilize support for `textDocument/inlayHint`.
* Stabilize all parts of semantic token support marked `proposed`.
* Stabilize completion label item details support.
* Stabilize support for insert text mode on `CompletionItem`s.
* Stabilize stale client request handling capability.

### Fixed

* Add missing `CompletionList` client capability.
* Add some missing API documentation.
* Update protocol reference links in `README.md`.

There was a _lot_ of work done here to bring `lsp-types` to actually support the 3.17.0 specification ([see official changelog](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#version_3_17_0)). I chose to not add in notebook support myself, since there seems to be a draft PR already open which tackles that (#229). This work should take care of everything else, though.

Closes #238.
Closes #251.
Closes #252.
Blocks https://github.com/ebkalderon/tower-lsp/issues/352.