### PR TITLE
Add support for work done ProgressToken by the initialize request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1085,6 +1085,11 @@ pub struct InitializeParams {
     /// @since 3.16.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
+
+    /// The LSP server may report about initialization progress to the client
+    /// by using the following work done token if it was passed by the client.
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
The work done progress token may be present in VSCode client with `LanguageClientOptions { progressOnInitialization: true }`

![Screenshot from 2023-02-18 15-17-15](https://user-images.githubusercontent.com/14666676/219877764-953318a1-a6ce-4f04-921e-432e6423fc95.png)
