### PR TITLE
Add support for textDocument/diagnostic and workspace/diagnostic (3.17)

### DIFF
--- a/src/document_diagnostic.rs
+++ b/src/document_diagnostic.rs
@@ -1,0 +1,269 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::{
+    Diagnostic, PartialResultParams, StaticRegistrationOptions, TextDocumentIdentifier,
+    TextDocumentRegistrationOptions, WorkDoneProgressOptions, WorkDoneProgressParams,
+};
+
+/// Client capabilities specific to diagnostic pull requests.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticClientCapabilities {
+    /// Whether implementation supports dynamic registration.
+    ///
+    /// If this is set to `true` the client supports the new `(TextDocumentRegistrationOptions &
+    /// StaticRegistrationOptions)` return value for the corresponding server capability as well.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dynamic_registration: Option<bool>,
+
+    /// Whether the clients supports related documents for document diagnostic pulls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related_document_support: Option<bool>,
+}
+
+/// Diagnostic options.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticOptions {
+    /// An optional identifier under which the diagnostics are
+    /// managed by the client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier: Option<String>,
+
+    /// Whether the language has inter file dependencies, meaning that editing code in one file can
+    /// result in a different diagnostic set in another file. Inter file dependencies are common
+    /// for most programming languages and typically uncommon for linters.
+    pub inter_file_dependencies: bool,
+
+    /// The server provides support for workspace diagnostics as well.
+    pub workspace_diagnostics: bool,
+
+    #[serde(flatten)]
+    pub work_done_progress_options: WorkDoneProgressOptions,
+}
+
+/// Diagnostic registration options.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticRegistrationOptions {
+    #[serde(flatten)]
+    pub text_document_registration_options: TextDocumentRegistrationOptions,
+
+    #[serde(flatten)]
+    pub diagnostic_options: DiagnosticOptions,
+
+    #[serde(flatten)]
+    pub static_registration_options: StaticRegistrationOptions,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum DiagnosticServerCapabilities {
+    Options(DiagnosticOptions),
+    RegistrationOptions(DiagnosticRegistrationOptions),
+}
+
+/// Parameters of the document diagnostic request.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentDiagnosticParams {
+    /// The text document.
+    pub text_document: TextDocumentIdentifier,
+
+    /// The additional identifier provided during registration.
+    pub identifier: Option<String>,
+
+    /// The result ID of a previous response if provided.
+    pub previous_result_id: Option<String>,
+
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
+
+    #[serde(flatten)]
+    pub partial_result_params: PartialResultParams,
+}
+
+/// A diagnostic report with a full set of problems.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FullDocumentDiagnosticReport {
+    /// An optional result ID. If provided it will be sent on the next diagnostic request for the
+    /// same document.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_id: Option<String>,
+
+    /// The actual items.
+    pub items: Vec<Diagnostic>,
+}
+
+/// A diagnostic report indicating that the last returned report is still accurate.
+///
+/// A server can only return `unchanged` if result ids are provided.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UnchangedDocumentDiagnosticReport {
+    /// A result ID which will be sent on the next diagnostic request for the same document.
+    pub result_id: String,
+}
+
+/// The document diagnostic report kinds.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum DocumentDiagnosticReportKind {
+    /// A diagnostic report with a full set of problems.
+    Full(FullDocumentDiagnosticReport),
+    /// A report indicating that the last returned report is still accurate.
+    Unchanged(UnchangedDocumentDiagnosticReport),
+}
+
+impl From<FullDocumentDiagnosticReport> for DocumentDiagnosticReportKind {
+    fn from(from: FullDocumentDiagnosticReport) -> Self {
+        DocumentDiagnosticReportKind::Full(from)
+    }
+}
+
+impl From<UnchangedDocumentDiagnosticReport> for DocumentDiagnosticReportKind {
+    fn from(from: UnchangedDocumentDiagnosticReport) -> Self {
+        DocumentDiagnosticReportKind::Unchanged(from)
+    }
+}
+
+/// A full diagnostic report with a set of related documents.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedFullDocumentDiagnosticReport {
+    /// Diagnostics of related documents.
+    ///
+    /// This information is useful in programming languages where code in a file A can generate
+    /// diagnostics in a file B which A depends on. An example of such a language is C/C++ where
+    /// macro definitions in a file `a.cpp` result in errors in a header file `b.hpp`.
+    ///
+    /// @since 3.17.0
+    #[serde(with = "crate::url_map")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub related_documents: Option<HashMap<Url, DocumentDiagnosticReportKind>>,
+    // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
+    #[serde(flatten)]
+    pub full_document_diagnostic_report: FullDocumentDiagnosticReport,
+}
+
+/// An unchanged diagnostic report with a set of related documents.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedUnchangedDocumentDiagnosticReport {
+    /// Diagnostics of related documents.
+    ///
+    /// This information is useful in programming languages where code in a file A can generate
+    /// diagnostics in a file B which A depends on. An example of such a language is C/C++ where
+    /// macro definitions in a file `a.cpp` result in errors in a header file `b.hpp`.
+    ///
+    /// @since 3.17.0
+    #[serde(with = "crate::url_map")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub related_documents: Option<HashMap<Url, DocumentDiagnosticReportKind>>,
+    // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
+    #[serde(flatten)]
+    pub unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport,
+}
+
+/// The result of a document diagnostic pull request.
+///
+/// A report can either be a full report containing all diagnostics for the requested document or
+/// an unchanged report indicating that nothing has changed in terms of diagnostics in comparison
+/// to the last pull request.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum DocumentDiagnosticReport {
+    /// A diagnostic report with a full set of problems.
+    Full(RelatedFullDocumentDiagnosticReport),
+    /// A report indicating that the last returned report is still accurate.
+    Unchanged(RelatedUnchangedDocumentDiagnosticReport),
+}
+
+impl From<RelatedFullDocumentDiagnosticReport> for DocumentDiagnosticReport {
+    fn from(from: RelatedFullDocumentDiagnosticReport) -> Self {
+        DocumentDiagnosticReport::Full(from)
+    }
+}
+
+impl From<RelatedUnchangedDocumentDiagnosticReport> for DocumentDiagnosticReport {
+    fn from(from: RelatedUnchangedDocumentDiagnosticReport) -> Self {
+        DocumentDiagnosticReport::Unchanged(from)
+    }
+}
+
+/// A partial result for a document diagnostic report.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentDiagnosticReportPartialResult {
+    #[serde(with = "crate::url_map")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub related_documents: Option<HashMap<Url, DocumentDiagnosticReportKind>>,
+    // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum DocumentDiagnosticReportResult {
+    Report(DocumentDiagnosticReport),
+    Partial(DocumentDiagnosticReportPartialResult),
+}
+
+impl From<DocumentDiagnosticReport> for DocumentDiagnosticReportResult {
+    fn from(from: DocumentDiagnosticReport) -> Self {
+        DocumentDiagnosticReportResult::Report(from)
+    }
+}
+
+impl From<DocumentDiagnosticReportPartialResult> for DocumentDiagnosticReportResult {
+    fn from(from: DocumentDiagnosticReportPartialResult) -> Self {
+        DocumentDiagnosticReportResult::Partial(from)
+    }
+}
+
+/// Cancellation data returned from a diagnostic request.
+///
+/// If no data is provided, it defaults to `{ retrigger_request: true }`.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticServerCancellationData {
+    pub retrigger_request: bool,
+}
+
+impl Default for DiagnosticServerCancellationData {
+    fn default() -> Self {
+        DiagnosticServerCancellationData {
+            retrigger_request: true,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,9 @@ pub use linked_editing::*;
 mod window;
 pub use window::*;
 
+mod workspace_diagnostic;
+pub use workspace_diagnostic::*;
+
 mod workspace_folders;
 pub use workspace_folders::*;
 
@@ -1338,6 +1341,11 @@ pub struct WorkspaceClientCapabilities {
     /// since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inlay_hint: Option<InlayHintWorkspaceClientCapabilities>,
+
+    /// Client workspace capabilities specific to diagnostics.
+    /// since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<DiagnosticWorkspaceClientCapabilities>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,9 @@ pub use color::*;
 mod completion;
 pub use completion::*;
 
+mod document_diagnostic;
+pub use document_diagnostic::*;
+
 mod document_highlight;
 pub use document_highlight::*;
 
@@ -780,18 +783,28 @@ pub struct ConfigurationItem {
 
 mod url_map {
     use std::fmt;
+    use std::marker::PhantomData;
 
     use super::*;
 
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<Option<HashMap<Url, Vec<TextEdit>>>, D::Error>
+    pub fn deserialize<'de, D, V>(deserializer: D) -> Result<Option<HashMap<Url, V>>, D::Error>
     where
         D: serde::Deserializer<'de>,
+        V: de::DeserializeOwned,
     {
-        struct UrlMapVisitor;
-        impl<'de> de::Visitor<'de> for UrlMapVisitor {
-            type Value = HashMap<Url, Vec<TextEdit>>;
+        struct UrlMapVisitor<V> {
+            _marker: PhantomData<V>,
+        }
+
+        impl<V: de::DeserializeOwned> Default for UrlMapVisitor<V> {
+            fn default() -> Self {
+                UrlMapVisitor {
+                    _marker: PhantomData,
+                }
+            }
+        }
+        impl<'de, V: de::DeserializeOwned> de::Visitor<'de> for UrlMapVisitor<V> {
+            type Value = HashMap<Url, V>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("map")
@@ -813,9 +826,18 @@ mod url_map {
             }
         }
 
-        struct OptionUrlMapVisitor;
-        impl<'de> de::Visitor<'de> for OptionUrlMapVisitor {
-            type Value = Option<HashMap<Url, Vec<TextEdit>>>;
+        struct OptionUrlMapVisitor<V> {
+            _marker: PhantomData<V>,
+        }
+        impl<V: de::DeserializeOwned> Default for OptionUrlMapVisitor<V> {
+            fn default() -> Self {
+                OptionUrlMapVisitor {
+                    _marker: PhantomData,
+                }
+            }
+        }
+        impl<'de, V: de::DeserializeOwned> de::Visitor<'de> for OptionUrlMapVisitor<V> {
+            type Value = Option<HashMap<Url, V>>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("option")
@@ -842,21 +864,24 @@ mod url_map {
             where
                 D: serde::Deserializer<'de>,
             {
-                deserializer.deserialize_map(UrlMapVisitor).map(Some)
+                deserializer
+                    .deserialize_map(UrlMapVisitor::<V>::default())
+                    .map(Some)
             }
         }
 
         // Instantiate our Visitor and ask the Deserializer to drive
         // it over the input data, resulting in an instance of MyMap.
-        deserializer.deserialize_option(OptionUrlMapVisitor)
+        deserializer.deserialize_option(OptionUrlMapVisitor::default())
     }
 
-    pub fn serialize<S>(
-        changes: &Option<HashMap<Url, Vec<TextEdit>>>,
+    pub fn serialize<S, V>(
+        changes: &Option<HashMap<Url, V>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
+        V: serde::Serialize,
     {
         use serde::ser::SerializeMap;
 
@@ -1535,6 +1560,12 @@ pub struct TextDocumentClientCapabilities {
     /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inlay_hint: Option<InlayHintClientCapabilities>,
+
+    /// Capabilities specific to the diagnostic pull model.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<DiagnosticClientCapabilities>,
 }
 
 /// Where ClientCapabilities are currently empty:
@@ -1965,6 +1996,12 @@ pub struct ServerCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub moniker_provider: Option<OneOf<bool, MonikerServerCapabilities>>,
 
+    /// The server provides linked editing range support.
+    ///
+    /// @since 3.16.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linked_editing_range_provider: Option<LinkedEditingRangeServerCapabilities>,
+
     /// The server provides inline values.
     ///
     /// @since 3.17.0
@@ -1977,11 +2014,11 @@ pub struct ServerCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inlay_hint_provider: Option<OneOf<bool, InlayHintServerCapabilities>>,
 
-    /// The server provides linked editing range support.
+    /// The server has support for pull model diagnostics.
     ///
-    /// @since 3.16.0
+    /// @since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linked_editing_range_provider: Option<LinkedEditingRangeServerCapabilities>,
+    pub diagnostic_provider: Option<DiagnosticServerCapabilities>,
 
     /// Experimental server capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/request.rs
+++ b/src/request.rs
@@ -162,6 +162,12 @@ macro_rules! lsp_request {
     ("textDocument/diagnostic") => {
         $crate::request::DocumentDiagnosticRequest
     };
+    ("workspace/diagnostic") => {
+        $crate::request::WorkspaceDiagnosticRequest
+    };
+    ("workspace/diagnostic/refresh") => {
+        $crate::request::WorkspaceDiagnosticRefresh
+    };
     ("typeHierarchy/supertypes") => {
         $crate::request::TypeHierarchySupertypes
     };
@@ -881,6 +887,34 @@ impl Request for DocumentDiagnosticRequest {
     const METHOD: &'static str = "textDocument/diagnostic";
 }
 
+/// The workspace diagnostic request is sent from the client to the server to ask the server to
+/// compute workspace wide diagnostics which previously where pushed from the server to the client.
+/// In contrast to the document diagnostic request the workspace request can be long running and is
+/// not bound to a specific workspace or document state. If the client supports streaming for the
+/// workspace diagnostic pull it is legal to provide a document diagnostic report multiple times
+/// for the same document URI. The last one reported will win over previous reports.
+#[derive(Debug)]
+pub enum WorkspaceDiagnosticRequest {}
+
+impl Request for WorkspaceDiagnosticRequest {
+    type Params = WorkspaceDiagnosticParams;
+    const METHOD: &'static str = "workspace/diagnostic";
+    type Result = WorkspaceDiagnosticReportResult;
+}
+
+/// The `workspace/diagnostic/refresh` request is sent from the server to the client. Servers can
+/// use it to ask clients to refresh all needed document and workspace diagnostics. This is useful
+/// if a server detects a project wide configuration change which requires a re-calculation of all
+/// diagnostics.
+#[derive(Debug)]
+pub enum WorkspaceDiagnosticRefresh {}
+
+impl Request for WorkspaceDiagnosticRefresh {
+    type Params = ();
+    type Result = ();
+    const METHOD: &'static str = "workspace/diagnostic/refresh";
+}
+
 /// The type hierarchy request is sent from the client to the server to return a type hierarchy for
 /// the language element of given text document positions. Will return null if the server couldn’t
 /// infer a valid type from the position. The type hierarchy requests are executed in two steps:
@@ -991,6 +1025,8 @@ mod test {
         check_macro!("workspace/symbol");
         check_macro!("workspace/executeCommand");
         check_macro!("workspace/configuration");
+        check_macro!("workspace/diagnostic");
+        check_macro!("workspace/diagnostic/refresh");
         check_macro!("workspace/willCreateFiles");
         check_macro!("workspace/willRenameFiles");
         check_macro!("workspace/willDeleteFiles");

--- a/src/request.rs
+++ b/src/request.rs
@@ -159,6 +159,9 @@ macro_rules! lsp_request {
     ("textDocument/inlineValue") => {
         $crate::request::InlineValueRequest
     };
+    ("textDocument/diagnostic") => {
+        $crate::request::DocumentDiagnosticRequest
+    };
     ("typeHierarchy/supertypes") => {
         $crate::request::TypeHierarchySupertypes
     };
@@ -866,6 +869,18 @@ impl Request for InlineValueRefreshRequest {
     const METHOD: &'static str = "workspace/inlineValue/refresh";
 }
 
+/// The text document diagnostic request is sent from the client to the server to ask the server to
+/// compute the diagnostics for a given document. As with other pull requests the server is asked
+/// to compute the diagnostics for the currently synced version of the document.
+#[derive(Debug)]
+pub enum DocumentDiagnosticRequest {}
+
+impl Request for DocumentDiagnosticRequest {
+    type Params = DocumentDiagnosticParams;
+    type Result = DocumentDiagnosticReportResult;
+    const METHOD: &'static str = "textDocument/diagnostic";
+}
+
 /// The type hierarchy request is sent from the client to the server to return a type hierarchy for
 /// the language element of given text document positions. Will return null if the server couldn’t
 /// infer a valid type from the position. The type hierarchy requests are executed in two steps:
@@ -970,6 +985,7 @@ mod test {
         check_macro!("textDocument/semanticTokens/range");
         check_macro!("textDocument/inlayHint");
         check_macro!("textDocument/inlineValue");
+        check_macro!("textDocument/diagnostic");
 
         check_macro!("workspace/applyEdit");
         check_macro!("workspace/symbol");

--- a/src/workspace_diagnostic.rs
+++ b/src/workspace_diagnostic.rs
@@ -1,0 +1,149 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::{
+    FullDocumentDiagnosticReport, PartialResultParams, UnchangedDocumentDiagnosticReport,
+    WorkDoneProgressParams,
+};
+
+/// Workspace client capabilities specific to diagnostic pull requests.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticWorkspaceClientCapabilities {
+    /// Whether the client implementation supports a refresh request sent from
+    /// the server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// pulled diagnostics currently shown. It should be used with absolute care
+    /// and is useful for situation where a server for example detects a project
+    /// wide change that requires such a calculation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_support: Option<bool>,
+}
+
+/// A previous result ID in a workspace pull request.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct PreviousResultId {
+    /// The URI for which the client knows a result ID.
+    pub uri: Url,
+
+    /// The value of the previous result ID.
+    pub value: String,
+}
+
+/// Parameters of the workspace diagnostic request.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceDiagnosticParams {
+    /// The additional identifier provided during registration.
+    pub identifier: Option<String>,
+
+    /// The currently known diagnostic reports with their
+    /// previous result ids.
+    pub previous_result_ids: Vec<PreviousResultId>,
+
+    #[serde(flatten)]
+    pub work_done_progress_params: WorkDoneProgressParams,
+
+    #[serde(flatten)]
+    pub partial_result_params: PartialResultParams,
+}
+
+/// A full document diagnostic report for a workspace diagnostic result.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceFullDocumentDiagnosticReport {
+    /// The URI for which diagnostic information is reported.
+    pub uri: Url,
+
+    /// The version number for which the diagnostics are reported.
+    ///
+    /// If the document is not marked as open, `None` can be provided.
+    pub version: Option<i64>,
+
+    #[serde(flatten)]
+    pub full_document_diagnostic_report: FullDocumentDiagnosticReport,
+}
+
+/// An unchanged document diagnostic report for a workspace diagnostic result.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceUnchangedDocumentDiagnosticReport {
+    /// The URI for which diagnostic information is reported.
+    pub uri: Url,
+
+    /// The version number for which the diagnostics are reported.
+    ///
+    /// If the document is not marked as open, `None` can be provided.
+    pub version: Option<i64>,
+
+    #[serde(flatten)]
+    pub unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport,
+}
+
+/// A workspace diagnostic document report.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum WorkspaceDocumentDiagnosticReport {
+    Full(WorkspaceFullDocumentDiagnosticReport),
+    Unchanged(WorkspaceUnchangedDocumentDiagnosticReport),
+}
+
+impl From<WorkspaceFullDocumentDiagnosticReport> for WorkspaceDocumentDiagnosticReport {
+    fn from(from: WorkspaceFullDocumentDiagnosticReport) -> Self {
+        WorkspaceDocumentDiagnosticReport::Full(from)
+    }
+}
+
+impl From<WorkspaceUnchangedDocumentDiagnosticReport> for WorkspaceDocumentDiagnosticReport {
+    fn from(from: WorkspaceUnchangedDocumentDiagnosticReport) -> Self {
+        WorkspaceDocumentDiagnosticReport::Unchanged(from)
+    }
+}
+
+/// A workspace diagnostic report.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+pub struct WorkspaceDiagnosticReport {
+    pub items: Vec<WorkspaceDocumentDiagnosticReport>,
+}
+
+/// A partial result for a workspace diagnostic report.
+///
+/// @since 3.17.0
+#[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+pub struct WorkspaceDiagnosticReportPartialResult {
+    pub items: Vec<WorkspaceDocumentDiagnosticReport>,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum WorkspaceDiagnosticReportResult {
+    Report(WorkspaceDiagnosticReport),
+    Partial(WorkspaceDiagnosticReportPartialResult),
+}
+
+impl From<WorkspaceDiagnosticReport> for WorkspaceDiagnosticReportResult {
+    fn from(from: WorkspaceDiagnosticReport) -> Self {
+        WorkspaceDiagnosticReportResult::Report(from)
+    }
+}
+
+impl From<WorkspaceDiagnosticReportPartialResult> for WorkspaceDiagnosticReportResult {
+    fn from(from: WorkspaceDiagnosticReportPartialResult) -> Self {
+        WorkspaceDiagnosticReportResult::Partial(from)
+    }
+}


### PR DESCRIPTION
### Added

* Add support for `textDocument/diagnostic` request ([link](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic)).
* Add support for `workspace/diagnostic` request ([link](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_diagnostic)).
* Add support for `workspace/diagnostic/refresh` request ([link](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic_refresh)).

### Changed

* Change `url_map()` to be generic over the `HashMap` value type, making this code reusable in `textDocument/diagnostic`.
* Add `diagnostic` field to `WorkspaceClientCapabilities` struct.
* Add `diagnostic` field to `TextDocumentClientCapabilities` struct.
* Add `diagnostic_provider` field to `ServerCapabilities` struct.

It turns out these new 3.17.0 requests were unfortunately missed in PR #255.