### PR TITLE
Fix incorrect params type for TelemetryEvent notification

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -167,7 +167,7 @@ impl Notification for LogMessage {
 pub enum TelemetryEvent {}
 
 impl Notification for TelemetryEvent {
-    type Params = serde_json::Value;
+    type Params = OneOf<LSPObject, LSPArray>;
     const METHOD: &'static str = "telemetry/event";
 }
 


### PR DESCRIPTION
### Fixed

* Changed `Params` for `TelemetryEvent` notification to `OneOf<LSPObject, LSPArray>`.

This pull request fixes a defect in the upstream LSP specification. According to https://github.com/microsoft/language-server-protocol/issues/1686, the `params` field of JSON-RPC message _must_ be of type `object | array`. The specification had previously incorrectly specified `telemetry/event` as having `params` of type `object | number | boolean | string` (basically a `serde_json::Value`) despite this violating the JSON-RPC 2.0 and LSP specs.