### PR TITLE
Fix missing `workspaceSymbol/resolve` for `lsp_request!`

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -31,6 +31,9 @@ macro_rules! lsp_request {
     ("workspace/symbol") => {
         $crate::request::WorkspaceSymbolRequest
     };
+    ("workspaceSymbol/resolve") => {
+        $crate::request::WorkspaceSymbolResolve
+    };
     ("workspace/executeCommand") => {
         $crate::request::ExecuteCommand
     };
@@ -993,6 +996,7 @@ mod test {
         check_macro!("inlayHint/resolve");
         check_macro!("typeHierarchy/subtypes");
         check_macro!("typeHierarchy/supertypes");
+        check_macro!("workspaceSymbol/resolve");
     }
 
     #[test]


### PR DESCRIPTION
This is missed from #255