### PR TITLE
Add `Send + Sync + 'static` bounds to associated types in `Request` and `Notification` traits

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -3,7 +3,7 @@ use super::*;
 use serde::{de::DeserializeOwned, Serialize};
 
 pub trait Notification {
-    type Params: DeserializeOwned + Serialize;
+    type Params: DeserializeOwned + Serialize + Send + Sync + 'static;
     const METHOD: &'static str;
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,8 +3,8 @@ use super::*;
 use serde::{de::DeserializeOwned, Serialize};
 
 pub trait Request {
-    type Params: DeserializeOwned + Serialize;
-    type Result: DeserializeOwned + Serialize;
+    type Params: DeserializeOwned + Serialize + Send + Sync + 'static;
+    type Result: DeserializeOwned + Serialize + Send + Sync + 'static;
     const METHOD: &'static str;
 }
 


### PR DESCRIPTION
This commits adds the `Send + Sync + 'static` bounds to the following
associated types:
- `Request::Params`
- `Request::Result`
- `Notification::Params`
All implementors of these traits supports these bounds, and they may
be needed in some generic context.
