### PR TITLE
Experiment with `derive_more`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.34", features = ["derive"] }
 serde_json = "1.0.50"
 serde_repr = "0.1"
 fluent-uri = "0.1.4"
+derive_more = "0.99"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "1.0.1"
 serde = { version = "1.0.34", features = ["derive"] }
 serde_json = "1.0.50"
 serde_repr = "0.1"
-url = {version = "2.0.0", features = ["serde"]}
+fluent-uri = "0.1.4"
 
 [features]
 default = []

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -1,10 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use url::Url;
 
 use crate::{
     DynamicRegistrationClientCapabilities, PartialResultParams, Range, SymbolKind, SymbolTag,
-    TextDocumentPositionParams, WorkDoneProgressOptions, WorkDoneProgressParams,
+    TextDocumentPositionParams, Uri, WorkDoneProgressOptions, WorkDoneProgressParams,
 };
 
 pub type CallHierarchyClientCapabilities = DynamicRegistrationClientCapabilities;
@@ -63,7 +62,7 @@ pub struct CallHierarchyItem {
     pub detail: Option<String>,
 
     /// The resource identifier of this item.
-    pub uri: Url,
+    pub uri: Uri,
 
     /// The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code.
     pub range: Range,

--- a/src/call_hierarchy.rs
+++ b/src/call_hierarchy.rs
@@ -15,23 +15,11 @@ pub struct CallHierarchyOptions {
     pub work_done_progress_options: WorkDoneProgressOptions,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, Copy, derive_more::From)]
 #[serde(untagged)]
 pub enum CallHierarchyServerCapability {
     Simple(bool),
     Options(CallHierarchyOptions),
-}
-
-impl From<CallHierarchyOptions> for CallHierarchyServerCapability {
-    fn from(from: CallHierarchyOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<bool> for CallHierarchyServerCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/code_action.rs
+++ b/src/code_action.rs
@@ -7,23 +7,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use std::borrow::Cow;
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum CodeActionProviderCapability {
     Simple(bool),
     Options(CodeActionOptions),
-}
-
-impl From<CodeActionOptions> for CodeActionProviderCapability {
-    fn from(from: CodeActionOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<bool> for CodeActionProviderCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
@@ -129,27 +117,15 @@ pub struct CodeActionParams {
 /// response for CodeActionRequest
 pub type CodeActionResponse = Vec<CodeActionOrCommand>;
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum CodeActionOrCommand {
     Command(Command),
     CodeAction(CodeAction),
 }
 
-impl From<Command> for CodeActionOrCommand {
-    fn from(command: Command) -> Self {
-        CodeActionOrCommand::Command(command)
-    }
-}
-
-impl From<CodeAction> for CodeActionOrCommand {
-    fn from(action: CodeAction) -> Self {
-        CodeActionOrCommand::CodeAction(action)
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
-pub struct CodeActionKind(Cow<'static, str>);
+#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize, derive_more::From)]
+pub struct CodeActionKind(#[from(forward)] Cow<'static, str>);
 
 impl CodeActionKind {
     /// Empty kind.
@@ -221,17 +197,6 @@ impl CodeActionKind {
     }
 }
 
-impl From<String> for CodeActionKind {
-    fn from(from: String) -> Self {
-        CodeActionKind(Cow::from(from))
-    }
-}
-
-impl From<&'static str> for CodeActionKind {
-    fn from(from: &'static str) -> Self {
-        CodeActionKind::new(from)
-    }
-}
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/color.rs
+++ b/src/color.rs
@@ -21,30 +21,12 @@ pub struct StaticTextDocumentColorProviderOptions {
     pub id: Option<String>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum ColorProviderCapability {
     Simple(bool),
     ColorProvider(ColorProviderOptions),
     Options(StaticTextDocumentColorProviderOptions),
-}
-
-impl From<ColorProviderOptions> for ColorProviderCapability {
-    fn from(from: ColorProviderOptions) -> Self {
-        Self::ColorProvider(from)
-    }
-}
-
-impl From<StaticTextDocumentColorProviderOptions> for ColorProviderCapability {
-    fn from(from: StaticTextDocumentColorProviderOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<bool> for ColorProviderCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -256,23 +256,11 @@ pub struct InsertReplaceEdit {
     pub replace: Range,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum CompletionTextEdit {
     Edit(TextEdit),
     InsertAndReplace(InsertReplaceEdit),
-}
-
-impl From<TextEdit> for CompletionTextEdit {
-    fn from(edit: TextEdit) -> Self {
-        CompletionTextEdit::Edit(edit)
-    }
-}
-
-impl From<InsertReplaceEdit> for CompletionTextEdit {
-    fn from(edit: InsertReplaceEdit) -> Self {
-        CompletionTextEdit::InsertAndReplace(edit)
-    }
 }
 
 /// Completion options.
@@ -340,23 +328,11 @@ pub struct CompletionRegistrationOptions {
     pub completion_options: CompletionOptions,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, derive_more::From)]
 #[serde(untagged)]
 pub enum CompletionResponse {
     Array(Vec<CompletionItem>),
     List(CompletionList),
-}
-
-impl From<Vec<CompletionItem>> for CompletionResponse {
-    fn from(items: Vec<CompletionItem>) -> Self {
-        CompletionResponse::Array(items)
-    }
-}
-
-impl From<CompletionList> for CompletionResponse {
-    fn from(list: CompletionList) -> Self {
-        CompletionResponse::List(list)
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/document_diagnostic.rs
+++ b/src/document_diagnostic.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::{
     Diagnostic, PartialResultParams, StaticRegistrationOptions, TextDocumentIdentifier,
-    TextDocumentRegistrationOptions, WorkDoneProgressOptions, WorkDoneProgressParams,
+    TextDocumentRegistrationOptions, Uri, WorkDoneProgressOptions, WorkDoneProgressParams,
 };
 
 /// Client capabilities specific to diagnostic pull requests.
@@ -158,10 +157,9 @@ pub struct RelatedFullDocumentDiagnosticReport {
     /// macro definitions in a file `a.cpp` result in errors in a header file `b.hpp`.
     ///
     /// @since 3.17.0
-    #[serde(with = "crate::url_map")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub related_documents: Option<HashMap<Url, DocumentDiagnosticReportKind>>,
+    pub related_documents: Option<HashMap<Uri, DocumentDiagnosticReportKind>>,
     // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
     #[serde(flatten)]
     pub full_document_diagnostic_report: FullDocumentDiagnosticReport,
@@ -180,10 +178,9 @@ pub struct RelatedUnchangedDocumentDiagnosticReport {
     /// macro definitions in a file `a.cpp` result in errors in a header file `b.hpp`.
     ///
     /// @since 3.17.0
-    #[serde(with = "crate::url_map")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub related_documents: Option<HashMap<Url, DocumentDiagnosticReportKind>>,
+    pub related_documents: Option<HashMap<Uri, DocumentDiagnosticReportKind>>,
     // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
     #[serde(flatten)]
     pub unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport,
@@ -223,10 +220,9 @@ impl From<RelatedUnchangedDocumentDiagnosticReport> for DocumentDiagnosticReport
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentDiagnosticReportPartialResult {
-    #[serde(with = "crate::url_map")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub related_documents: Option<HashMap<Url, DocumentDiagnosticReportKind>>,
+    pub related_documents: Option<HashMap<Uri, DocumentDiagnosticReportKind>>,
     // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
 }
 

--- a/src/document_diagnostic.rs
+++ b/src/document_diagnostic.rs
@@ -123,25 +123,13 @@ pub struct UnchangedDocumentDiagnosticReport {
 /// The document diagnostic report kinds.
 ///
 /// @since 3.17.0
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, derive_more::From)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum DocumentDiagnosticReportKind {
     /// A diagnostic report with a full set of problems.
     Full(FullDocumentDiagnosticReport),
     /// A report indicating that the last returned report is still accurate.
     Unchanged(UnchangedDocumentDiagnosticReport),
-}
-
-impl From<FullDocumentDiagnosticReport> for DocumentDiagnosticReportKind {
-    fn from(from: FullDocumentDiagnosticReport) -> Self {
-        DocumentDiagnosticReportKind::Full(from)
-    }
-}
-
-impl From<UnchangedDocumentDiagnosticReport> for DocumentDiagnosticReportKind {
-    fn from(from: UnchangedDocumentDiagnosticReport) -> Self {
-        DocumentDiagnosticReportKind::Unchanged(from)
-    }
 }
 
 /// A full diagnostic report with a set of related documents.
@@ -193,25 +181,13 @@ pub struct RelatedUnchangedDocumentDiagnosticReport {
 /// to the last pull request.
 ///
 /// @since 3.17.0
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, derive_more::From)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum DocumentDiagnosticReport {
     /// A diagnostic report with a full set of problems.
     Full(RelatedFullDocumentDiagnosticReport),
     /// A report indicating that the last returned report is still accurate.
     Unchanged(RelatedUnchangedDocumentDiagnosticReport),
-}
-
-impl From<RelatedFullDocumentDiagnosticReport> for DocumentDiagnosticReport {
-    fn from(from: RelatedFullDocumentDiagnosticReport) -> Self {
-        DocumentDiagnosticReport::Full(from)
-    }
-}
-
-impl From<RelatedUnchangedDocumentDiagnosticReport> for DocumentDiagnosticReport {
-    fn from(from: RelatedUnchangedDocumentDiagnosticReport) -> Self {
-        DocumentDiagnosticReport::Unchanged(from)
-    }
 }
 
 /// A partial result for a document diagnostic report.
@@ -226,23 +202,11 @@ pub struct DocumentDiagnosticReportPartialResult {
     // relatedDocuments?: { [uri: string]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport; };
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, derive_more::From)]
 #[serde(untagged)]
 pub enum DocumentDiagnosticReportResult {
     Report(DocumentDiagnosticReport),
     Partial(DocumentDiagnosticReportPartialResult),
-}
-
-impl From<DocumentDiagnosticReport> for DocumentDiagnosticReportResult {
-    fn from(from: DocumentDiagnosticReport) -> Self {
-        DocumentDiagnosticReportResult::Report(from)
-    }
-}
-
-impl From<DocumentDiagnosticReportPartialResult> for DocumentDiagnosticReportResult {
-    fn from(from: DocumentDiagnosticReportPartialResult) -> Self {
-        DocumentDiagnosticReportResult::Partial(from)
-    }
 }
 
 /// Cancellation data returned from a diagnostic request.

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -1,10 +1,9 @@
 use crate::{
-    PartialResultParams, Range, TextDocumentIdentifier, WorkDoneProgressOptions,
+    PartialResultParams, Range, TextDocumentIdentifier, Uri, WorkDoneProgressOptions,
     WorkDoneProgressParams,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use url::Url;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -50,7 +49,7 @@ pub struct DocumentLink {
     pub range: Range,
     /// The uri this link points to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target: Option<Url>,
+    pub target: Option<Uri>,
 
     /// The tooltip text when you hover over this link.
     ///

--- a/src/document_symbols.rs
+++ b/src/document_symbols.rs
@@ -35,23 +35,11 @@ pub struct DocumentSymbolClientCapabilities {
     pub tag_support: Option<TagSupport<SymbolTag>>,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, derive_more::From)]
 #[serde(untagged)]
 pub enum DocumentSymbolResponse {
     Flat(Vec<SymbolInformation>),
     Nested(Vec<DocumentSymbol>),
-}
-
-impl From<Vec<SymbolInformation>> for DocumentSymbolResponse {
-    fn from(info: Vec<SymbolInformation>) -> Self {
-        DocumentSymbolResponse::Flat(info)
-    }
-}
-
-impl From<Vec<DocumentSymbol>> for DocumentSymbolResponse {
-    fn from(symbols: Vec<DocumentSymbol>) -> Self {
-        DocumentSymbolResponse::Nested(symbols)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/folding_range.rs
+++ b/src/folding_range.rs
@@ -16,30 +16,12 @@ pub struct FoldingRangeParams {
     pub partial_result_params: PartialResultParams,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum FoldingRangeProviderCapability {
     Simple(bool),
     FoldingProvider(FoldingProviderOptions),
     Options(StaticTextDocumentColorProviderOptions),
-}
-
-impl From<StaticTextDocumentColorProviderOptions> for FoldingRangeProviderCapability {
-    fn from(from: StaticTextDocumentColorProviderOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<FoldingProviderOptions> for FoldingRangeProviderCapability {
-    fn from(from: FoldingProviderOptions) -> Self {
-        Self::FoldingProvider(from)
-    }
-}
-
-impl From<bool> for FoldingRangeProviderCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -36,23 +36,11 @@ pub struct HoverRegistrationOptions {
     pub hover_options: HoverOptions,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum HoverProviderCapability {
     Simple(bool),
     Options(HoverOptions),
-}
-
-impl From<HoverOptions> for HoverProviderCapability {
-    fn from(from: HoverOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<bool> for HoverProviderCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/inlay_hint.rs
+++ b/src/inlay_hint.rs
@@ -136,46 +136,18 @@ pub struct InlayHint {
     pub data: Option<LSPAny>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum InlayHintLabel {
     String(String),
     LabelParts(Vec<InlayHintLabelPart>),
 }
 
-impl From<String> for InlayHintLabel {
-    #[inline]
-    fn from(from: String) -> Self {
-        Self::String(from)
-    }
-}
-
-impl From<Vec<InlayHintLabelPart>> for InlayHintLabel {
-    #[inline]
-    fn from(from: Vec<InlayHintLabelPart>) -> Self {
-        Self::LabelParts(from)
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum InlayHintTooltip {
     String(String),
     MarkupContent(MarkupContent),
-}
-
-impl From<String> for InlayHintTooltip {
-    #[inline]
-    fn from(from: String) -> Self {
-        Self::String(from)
-    }
-}
-
-impl From<MarkupContent> for InlayHintTooltip {
-    #[inline]
-    fn from(from: MarkupContent) -> Self {
-        Self::MarkupContent(from)
-    }
 }
 
 /// An inlay hint label part allows for interactive and composite labels
@@ -214,25 +186,11 @@ pub struct InlayHintLabelPart {
     pub command: Option<Command>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum InlayHintLabelPartTooltip {
     String(String),
     MarkupContent(MarkupContent),
-}
-
-impl From<String> for InlayHintLabelPartTooltip {
-    #[inline]
-    fn from(from: String) -> Self {
-        Self::String(from)
-    }
-}
-
-impl From<MarkupContent> for InlayHintLabelPartTooltip {
-    #[inline]
-    fn from(from: MarkupContent) -> Self {
-        Self::MarkupContent(from)
-    }
 }
 
 /// Inlay hint kinds.

--- a/src/inline_value.rs
+++ b/src/inline_value.rs
@@ -135,33 +135,12 @@ pub struct InlineValueEvaluatableExpression {
 /// The InlineValue types combines all inline value types into one type.
 ///
 /// @since 3.17.0
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum InlineValue {
     Text(InlineValueText),
     VariableLookup(InlineValueVariableLookup),
     EvaluatableExpression(InlineValueEvaluatableExpression),
-}
-
-impl From<InlineValueText> for InlineValue {
-    #[inline]
-    fn from(from: InlineValueText) -> Self {
-        Self::Text(from)
-    }
-}
-
-impl From<InlineValueVariableLookup> for InlineValue {
-    #[inline]
-    fn from(from: InlineValueVariableLookup) -> Self {
-        Self::VariableLookup(from)
-    }
-}
-
-impl From<InlineValueEvaluatableExpression> for InlineValue {
-    #[inline]
-    fn from(from: InlineValueEvaluatableExpression) -> Self {
-        Self::EvaluatableExpression(from)
-    }
 }
 
 /// Client workspace capabilities specific to inline values.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate bitflags;
 
 use std::{collections::HashMap, fmt::Debug};
 
+use derive_more::From;
 use serde::{de, de::Error, Deserialize, Serialize};
 use serde_json::Value;
 
@@ -301,8 +302,8 @@ pub struct LocationLink {
 /// specifically what column offsets mean.
 ///
 /// @since 3.17.0
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
-pub struct PositionEncodingKind(std::borrow::Cow<'static, str>);
+#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize, From)]
+pub struct PositionEncodingKind(#[from(forward)] std::borrow::Cow<'static, str>);
 
 impl PositionEncodingKind {
     /// Character offsets count UTF-8 code units.
@@ -327,18 +328,6 @@ impl PositionEncodingKind {
 
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-}
-
-impl From<String> for PositionEncodingKind {
-    fn from(from: String) -> Self {
-        PositionEncodingKind(std::borrow::Cow::from(from))
-    }
-}
-
-impl From<&'static str> for PositionEncodingKind {
-    fn from(from: &'static str) -> Self {
-        PositionEncodingKind::new(from)
     }
 }
 
@@ -1667,23 +1656,11 @@ pub struct SaveOptions {
     pub include_text: Option<bool>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(untagged)]
 pub enum TextDocumentSyncSaveOptions {
     Supported(bool),
     SaveOptions(SaveOptions),
-}
-
-impl From<SaveOptions> for TextDocumentSyncSaveOptions {
-    fn from(from: SaveOptions) -> Self {
-        Self::SaveOptions(from)
-    }
-}
-
-impl From<bool> for TextDocumentSyncSaveOptions {
-    fn from(from: bool) -> Self {
-        Self::Supported(from)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
@@ -1718,61 +1695,25 @@ pub enum OneOf<A, B> {
     Right(B),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(untagged)]
 pub enum TextDocumentSyncCapability {
     Kind(TextDocumentSyncKind),
     Options(TextDocumentSyncOptions),
 }
 
-impl From<TextDocumentSyncOptions> for TextDocumentSyncCapability {
-    fn from(from: TextDocumentSyncOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<TextDocumentSyncKind> for TextDocumentSyncCapability {
-    fn from(from: TextDocumentSyncKind) -> Self {
-        Self::Kind(from)
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(untagged)]
 pub enum ImplementationProviderCapability {
     Simple(bool),
     Options(StaticTextDocumentRegistrationOptions),
 }
 
-impl From<StaticTextDocumentRegistrationOptions> for ImplementationProviderCapability {
-    fn from(from: StaticTextDocumentRegistrationOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<bool> for ImplementationProviderCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(untagged)]
 pub enum TypeDefinitionProviderCapability {
     Simple(bool),
     Options(StaticTextDocumentRegistrationOptions),
-}
-
-impl From<StaticTextDocumentRegistrationOptions> for TypeDefinitionProviderCapability {
-    fn from(from: StaticTextDocumentRegistrationOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<bool> for TypeDefinitionProviderCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
@@ -2307,25 +2248,11 @@ pub struct FileSystemWatcher {
 /// The glob pattern. Either a string pattern or a relative pattern.
 ///
 /// @since 3.17.0
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Deserialize, Serialize, From)]
 #[serde(untagged)]
 pub enum GlobPattern {
     String(Pattern),
     Relative(RelativePattern),
-}
-
-impl From<Pattern> for GlobPattern {
-    #[inline]
-    fn from(from: Pattern) -> Self {
-        Self::String(from)
-    }
-}
-
-impl From<RelativePattern> for GlobPattern {
-    #[inline]
-    fn from(from: RelativePattern) -> Self {
-        Self::Relative(from)
-    }
 }
 
 /// A relative pattern is a helper to construct glob patterns that are matched
@@ -2476,30 +2403,12 @@ pub struct GotoDefinitionParams {
 }
 
 /// GotoDefinition response can be single location, or multiple Locations or a link.
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, From)]
 #[serde(untagged)]
 pub enum GotoDefinitionResponse {
     Scalar(Location),
     Array(Vec<Location>),
     Link(Vec<LocationLink>),
-}
-
-impl From<Location> for GotoDefinitionResponse {
-    fn from(location: Location) -> Self {
-        GotoDefinitionResponse::Scalar(location)
-    }
-}
-
-impl From<Vec<Location>> for GotoDefinitionResponse {
-    fn from(locations: Vec<Location>) -> Self {
-        GotoDefinitionResponse::Array(locations)
-    }
-}
-
-impl From<Vec<LocationLink>> for GotoDefinitionResponse {
-    fn from(locations: Vec<LocationLink>) -> Self {
-        GotoDefinitionResponse::Link(locations)
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,9 @@ pub use document_link::*;
 mod document_symbols;
 pub use document_symbols::*;
 
+mod notebook;
+pub use notebook::*;
+
 mod file_operations;
 pub use file_operations::*;
 
@@ -1469,6 +1472,12 @@ pub struct ClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_document: Option<TextDocumentClientCapabilities>,
 
+    /// Capabilities specific to the notebook document support.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notebook_document: Option<NotebookDocumentClientCapabilities>,
+
     /// Window specific client capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub window: Option<WindowClientCapabilities>,
@@ -1784,6 +1793,13 @@ pub struct ServerCapabilities {
     /// Defines how text documents are synced.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_document_sync: Option<TextDocumentSyncCapability>,
+
+    /// Defines how notebook documents are synced.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notebook_document_sync:
+        Option<OneOf<NotebookDocumentSyncOptions, NotebookDocumentSyncRegistrationOptions>>,
 
     /// Capabilities specific to `textDocument/selectionRange` requests.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lsif.rs
+++ b/src/lsif.rs
@@ -4,7 +4,7 @@
 //!
 //! Based on <https://microsoft.github.io/language-server-protocol/specifications/lsif/0.6.0/specification/>
 
-use crate::{Range, Url};
+use crate::{Range, Uri};
 use serde::{Deserialize, Serialize};
 
 pub type Id = crate::NumberOrString;
@@ -268,7 +268,7 @@ pub struct Item {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Document {
-    pub uri: Url,
+    pub uri: Uri,
     pub language_id: String,
 }
 
@@ -285,7 +285,7 @@ pub struct ResultSet {
 #[serde(rename_all = "camelCase")]
 pub struct Project {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource: Option<Url>,
+    pub resource: Option<Uri>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     pub kind: String,
@@ -300,7 +300,7 @@ pub struct MetaData {
     pub version: String,
 
     /// The project root (in form of an URI) used to compute this dump.
-    pub project_root: Url,
+    pub project_root: Uri,
 
     /// The string encoding used to compute line and character values in
     /// positions and ranges.
@@ -326,7 +326,7 @@ pub struct PackageInformation {
     pub name: String,
     pub manager: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uri: Option<Url>,
+    pub uri: Option<Uri>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1,0 +1,432 @@
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::{LSPObject, Uri};
+
+pub use notification_params::*;
+
+/// A notebook document.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocument {
+    /// The notebook document's URI.
+    pub uri: Uri,
+    /// The type of the notebook.
+    pub notebook_type: String,
+    /// The version number of this document (it will increase after each
+    /// change, including undo/redo).
+    pub version: i32,
+    /// Additional metadata stored with the notebook
+    /// document.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<LSPObject>,
+    /// The cells of a notebook.
+    pub cells: Vec<NotebookCell>,
+}
+
+/// A notebook cell.
+///
+/// A cell's document URI must be unique across ALL notebook
+/// cells and can therefore be used to uniquely identify a
+/// notebook cell or the cell's text document.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookCell {
+    /// The cell's kind
+    pub kind: NotebookCellKind,
+    /// The URI of the cell's text document content.
+    pub document: Uri,
+    /// Additional metadata stored with the cell.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<LSPObject>,
+    /// Additional execution summary information
+    /// if supported by the client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_summary: Option<ExecutionSummary>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionSummary {
+    /// A strict monotonically increasing value
+    /// indicating the execution order of a cell
+    /// inside a notebook.
+    pub execution_order: u32,
+    /// Whether the execution was successful or
+    /// not if known by the client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum NotebookCellKind {
+    /// A markup-cell is formatted source that is used for display.
+    Markup = 1,
+    /// A code-cell is source code.
+    Code = 2,
+}
+
+/// Capabilities specific to the notebook document support.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentClientCapabilities {
+    /// Capabilities specific to notebook document synchronization
+    ///
+    /// @since 3.17.0
+    pub synchronization: NotebookDocumentSyncClientCapabilities,
+}
+
+/// Notebook specific client capabilities.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentSyncClientCapabilities {
+    /// Whether implementation supports dynamic registration. If this is
+    /// set to `true` the client supports the new
+    /// `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dynamic_registration: Option<bool>,
+
+    /// The client supports sending execution summary data per cell.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_summary_report: Option<bool>,
+}
+
+///  Options specific to a notebook plus its cells
+///  to be synced to the server.
+///
+///  If a selector provides a notebook document
+///  filter but no cell selector all cells of a
+///  matching notebook document will be synced.
+///
+///  If a selector provides no notebook document
+///  filter but only a cell selector all notebook
+///  documents that contain at least one matching
+///  cell will be synced.
+///
+///  @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentSyncOptions {
+    /// The notebooks to be synced
+    pub notebook_selector: Vec<NotebookSelector>,
+    /// Whether save notification should be forwarded to
+    /// the server. Will only be honored if mode === `notebook`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save: Option<bool>,
+}
+
+/// Registration options specific to a notebook.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentSyncRegistrationOptions {
+    /// The notebooks to be synced
+    pub notebook_selector: Vec<NotebookSelector>,
+    /// Whether save notification should be forwarded to
+    /// the server. Will only be honored if mode === `notebook`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save: Option<bool>,
+    /// The id used to register the request. The id can be used to deregister
+    /// the request again. See also Registration#id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+}
+
+/// A notebook cell text document filter denotes a cell text
+/// document by different properties.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookCellTextDocumentFilter {
+    /// A filter that matches against the notebook
+    /// containing the notebook cell. If a string
+    /// value is provided it matches against the
+    /// notebook type. '*' matches every notebook.
+    pub notebook: Notebook,
+    /// A language id like `python`.
+    ///
+    /// Will be matched against the language id of the
+    /// notebook cell document. '*' matches every language.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NotebookSelector {
+    ByNotebook(NotebookSelectorByNotebook),
+    ByCells(NotebookSelectorByCells),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookSelectorByNotebook {
+    /// The notebook to be synced. If a string
+    /// value is provided it matches against the
+    /// notebook type. '*' matches every notebook.
+    pub notebook: Notebook,
+    /// The cells of the matching notebook to be synced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cells: Option<Vec<NotebookCellSelector>>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookSelectorByCells {
+    /// The notebook to be synced. If a string
+    /// value is provided it matches against the
+    /// notebook type. '*' matches every notebook.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notebook: Option<Notebook>,
+    /// The cells of the matching notebook to be synced.
+    pub cells: Vec<NotebookCellSelector>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookCellSelector {
+    pub language: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Notebook {
+    String(String),
+    NotebookDocumentFilter(NotebookDocumentFilter),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum NotebookDocumentFilter {
+    ByType(NotebookDocumentFilterByType),
+    ByScheme(NotebookDocumentFilterByScheme),
+    ByPattern(NotebookDocumentFilterByPattern),
+}
+
+/// A notebook document filter denotes a notebook document by
+/// different properties.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentFilterByType {
+    /// The type of the enclosing notebook.
+    pub notebook_type: String,
+    /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
+    /// A glob pattern.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+}
+
+/// A notebook document filter denotes a notebook document by
+/// different properties.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentFilterByScheme {
+    /// The type of the enclosing notebook.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notebook_type: Option<String>,
+    /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    pub scheme: String,
+    /// A glob pattern.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+}
+
+/// A notebook document filter denotes a notebook document by
+/// different properties.
+///
+/// @since 3.17.0
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotebookDocumentFilterByPattern {
+    /// The type of the enclosing notebook.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notebook_type: Option<String>,
+    /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
+    /// A glob pattern.
+    pub pattern: String,
+}
+
+mod notification_params {
+    use serde::{Deserialize, Serialize};
+
+    use crate::{
+        TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
+        VersionedTextDocumentIdentifier,
+    };
+
+    use super::*;
+
+    /// The params sent in an open notebook document notification.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DidOpenNotebookDocumentParams {
+        /// The notebook document that got opened.
+        pub notebook_document: NotebookDocument,
+        /// The text documents that represent the content
+        /// of a notebook cell.
+        pub cell_text_documents: Vec<TextDocumentItem>,
+    }
+
+    /// The params sent in a change notebook document notification.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DidChangeNotebookDocumentParams {
+        /// The notebook document that did change. The version number points
+        /// to the version after all provided changes have been applied.
+        pub notebook_document: VersionedNotebookDocumentIdentifier,
+
+        /// The actual changes to the notebook document.
+        ///
+        /// The change describes single state change to the notebook document.
+        /// So it moves a notebook document, its cells and its cell text document
+        /// contents from state S to S'.
+        ///
+        /// To mirror the content of a notebook using change events use the
+        /// following approach:
+        /// - start with the same initial content
+        /// - apply the 'notebookDocument/didChange' notifications in the order
+        ///   you receive them.
+        pub change: NotebookDocumentChangeEvent,
+    }
+
+    /// A versioned notebook document identifier.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct VersionedNotebookDocumentIdentifier {
+        /// The version number of this notebook document.
+        pub version: i32,
+        /// The notebook document's URI.
+        pub uri: Uri,
+    }
+
+    /// A change event for a notebook document.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NotebookDocumentChangeEvent {
+        /// The changed meta data if any.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub metadata: Option<LSPObject>,
+
+        /// Changes to cells
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub cells: Option<NotebookDocumentCellChange>,
+    }
+
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NotebookDocumentCellChange {
+        /// Changes to the cell structure to add or
+        /// remove cells.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub structure: Option<NotebookDocumentCellChangeStructure>,
+
+        /// Changes to notebook cells properties like its
+        /// kind, execution summary or metadata.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub data: Option<Vec<NotebookCell>>,
+
+        /// Changes to the text content of notebook cells.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub text_content: Option<Vec<NotebookDocumentChangeTextContent>>,
+    }
+
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NotebookDocumentChangeTextContent {
+        pub document: VersionedTextDocumentIdentifier,
+        pub changes: Vec<TextDocumentContentChangeEvent>,
+    }
+
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NotebookDocumentCellChangeStructure {
+        /// The change to the cell array.
+        pub array: NotebookCellArrayChange,
+        /// Additional opened cell text documents.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub did_open: Option<Vec<TextDocumentItem>>,
+        /// Additional closed cell text documents.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub did_close: Option<Vec<TextDocumentIdentifier>>,
+    }
+
+    /// A change describing how to move a `NotebookCell`
+    /// array from state S to S'.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NotebookCellArrayChange {
+        /// The start offset of the cell that changed.
+        pub start: u32,
+
+        /// The deleted cells
+        pub delete_count: u32,
+
+        /// The new cells, if any
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub cells: Option<Vec<NotebookCell>>,
+    }
+
+    /// The params sent in a save notebook document notification.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DidSaveNotebookDocumentParams {
+        /// The notebook document that got saved.
+        pub notebook_document: NotebookDocumentIdentifier,
+    }
+
+    /// A literal to identify a notebook document in the client.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NotebookDocumentIdentifier {
+        /// The notebook document's URI.
+        pub uri: Uri,
+    }
+
+    /// The params sent in a close notebook document notification.
+    ///
+    /// @since 3.17.0
+    #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DidCloseNotebookDocumentParams {
+        /// The notebook document that got closed.
+        pub notebook_document: NotebookDocumentIdentifier,
+
+        /// The text documents that represent the content
+        /// of a notebook cell that got closed.
+        pub cell_text_documents: Vec<TextDocumentIdentifier>,
+    }
+}

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -164,34 +164,26 @@ pub struct NotebookCellTextDocumentFilter {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(untagged)]
+#[serde(rename_all = "camelCase", untagged)]
 pub enum NotebookSelector {
-    ByNotebook(NotebookSelectorByNotebook),
-    ByCells(NotebookSelectorByCells),
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NotebookSelectorByNotebook {
-    /// The notebook to be synced. If a string
-    /// value is provided it matches against the
-    /// notebook type. '*' matches every notebook.
-    pub notebook: Notebook,
-    /// The cells of the matching notebook to be synced.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cells: Option<Vec<NotebookCellSelector>>,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NotebookSelectorByCells {
-    /// The notebook to be synced. If a string
-    /// value is provided it matches against the
-    /// notebook type. '*' matches every notebook.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub notebook: Option<Notebook>,
-    /// The cells of the matching notebook to be synced.
-    pub cells: Vec<NotebookCellSelector>,
+    ByNotebook {
+        /// The notebook to be synced. If a string
+        /// value is provided it matches against the
+        /// notebook type. '*' matches every notebook.
+        notebook: Notebook,
+        /// The cells of the matching notebook to be synced.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cells: Option<Vec<NotebookCellSelector>>,
+    },
+    ByCells {
+        /// The notebook to be synced. If a string
+        /// value is provided it matches against the
+        /// notebook type. '*' matches every notebook.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        notebook: Option<Notebook>,
+        /// The cells of the matching notebook to be synced.
+        cells: Vec<NotebookCellSelector>,
+    },
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
@@ -207,63 +199,43 @@ pub enum Notebook {
     NotebookDocumentFilter(NotebookDocumentFilter),
 }
 
+/// A notebook document filter denotes a notebook document by
+/// different properties.
+///
+/// @since 3.17.0
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(untagged)]
+#[serde(rename_all = "camelCase", untagged)]
 pub enum NotebookDocumentFilter {
-    ByType(NotebookDocumentFilterByType),
-    ByScheme(NotebookDocumentFilterByScheme),
-    ByPattern(NotebookDocumentFilterByPattern),
-}
-
-/// A notebook document filter denotes a notebook document by
-/// different properties.
-///
-/// @since 3.17.0
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NotebookDocumentFilterByType {
-    /// The type of the enclosing notebook.
-    pub notebook_type: String,
-    /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheme: Option<String>,
-    /// A glob pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pattern: Option<String>,
-}
-
-/// A notebook document filter denotes a notebook document by
-/// different properties.
-///
-/// @since 3.17.0
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NotebookDocumentFilterByScheme {
-    /// The type of the enclosing notebook.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub notebook_type: Option<String>,
-    /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
-    pub scheme: String,
-    /// A glob pattern.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pattern: Option<String>,
-}
-
-/// A notebook document filter denotes a notebook document by
-/// different properties.
-///
-/// @since 3.17.0
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NotebookDocumentFilterByPattern {
-    /// The type of the enclosing notebook.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub notebook_type: Option<String>,
-    /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheme: Option<String>,
-    /// A glob pattern.
-    pub pattern: String,
+    ByType {
+        /// The type of the enclosing notebook.
+        notebook_type: String,
+        /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        scheme: Option<String>,
+        /// A glob pattern.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pattern: Option<String>,
+    },
+    ByScheme {
+        /// The type of the enclosing notebook.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        notebook_type: Option<String>,
+        /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+        scheme: String,
+        /// A glob pattern.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pattern: Option<String>,
+    },
+    ByPattern {
+        /// The type of the enclosing notebook.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        notebook_type: Option<String>,
+        /// A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        scheme: Option<String>,
+        /// A glob pattern.
+        pattern: String,
+    },
 }
 
 mod notification_params {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -58,6 +58,19 @@ macro_rules! lsp_notification {
         $crate::notification::PublishDiagnostics
     };
 
+    ("notebookDocument/didOpen") => {
+        $crate::notification::DidOpenNotebookDocument
+    };
+    ("notebookDocument/didChange") => {
+        $crate::notification::DidChangeNotebookDocument
+    };
+    ("notebookDocument/didSave") => {
+        $crate::notification::DidSaveNotebookDocument
+    };
+    ("notebookDocument/didClose") => {
+        $crate::notification::DidCloseNotebookDocument
+    };
+
     ("workspace/didChangeConfiguration") => {
         $crate::notification::DidChangeConfiguration
     };
@@ -229,6 +242,34 @@ pub enum DidSaveTextDocument {}
 impl Notification for DidSaveTextDocument {
     type Params = DidSaveTextDocumentParams;
     const METHOD: &'static str = "textDocument/didSave";
+}
+
+#[derive(Debug)]
+pub enum DidOpenNotebookDocument {}
+impl Notification for DidOpenNotebookDocument {
+    type Params = DidOpenNotebookDocumentParams;
+    const METHOD: &'static str = "notebookDocument/didOpen";
+}
+
+#[derive(Debug)]
+pub enum DidChangeNotebookDocument {}
+impl Notification for DidChangeNotebookDocument {
+    type Params = DidChangeNotebookDocumentParams;
+    const METHOD: &'static str = "notebookDocument/didChange";
+}
+
+#[derive(Debug)]
+pub enum DidSaveNotebookDocument {}
+impl Notification for DidSaveNotebookDocument {
+    type Params = DidSaveNotebookDocumentParams;
+    const METHOD: &'static str = "notebookDocument/didSave";
+}
+
+#[derive(Debug)]
+pub enum DidCloseNotebookDocument {}
+impl Notification for DidCloseNotebookDocument {
+    type Params = DidCloseNotebookDocumentParams;
+    const METHOD: &'static str = "notebookDocument/didClose";
 }
 
 /// The watched files notification is sent from the client to the server when the client detects changes to files and folders

--- a/src/selection_range.rs
+++ b/src/selection_range.rs
@@ -30,30 +30,12 @@ pub struct SelectionRangeRegistrationOptions {
     pub registration_options: StaticTextDocumentRegistrationOptions,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, derive_more::From)]
 #[serde(untagged)]
 pub enum SelectionRangeProviderCapability {
     Simple(bool),
     Options(SelectionRangeOptions),
     RegistrationOptions(SelectionRangeRegistrationOptions),
-}
-
-impl From<SelectionRangeRegistrationOptions> for SelectionRangeProviderCapability {
-    fn from(from: SelectionRangeRegistrationOptions) -> Self {
-        Self::RegistrationOptions(from)
-    }
-}
-
-impl From<SelectionRangeOptions> for SelectionRangeProviderCapability {
-    fn from(from: SelectionRangeOptions) -> Self {
-        Self::Options(from)
-    }
-}
-
-impl From<bool> for SelectionRangeProviderCapability {
-    fn from(from: bool) -> Self {
-        Self::Simple(from)
-    }
 }
 
 /// A parameter literal used in selection range requests.

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use derive_more::From;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 
@@ -12,8 +13,8 @@ use crate::{
 /// corresponding client capabilities.
 ///
 /// @since 3.16.0
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
-pub struct SemanticTokenType(Cow<'static, str>);
+#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize, From)]
+pub struct SemanticTokenType(#[from(forward)] Cow<'static, str>);
 
 impl SemanticTokenType {
     pub const NAMESPACE: SemanticTokenType = SemanticTokenType::new("namespace");
@@ -51,25 +52,13 @@ impl SemanticTokenType {
     }
 }
 
-impl From<String> for SemanticTokenType {
-    fn from(from: String) -> Self {
-        SemanticTokenType(Cow::from(from))
-    }
-}
-
-impl From<&'static str> for SemanticTokenType {
-    fn from(from: &'static str) -> Self {
-        SemanticTokenType::new(from)
-    }
-}
-
 /// A set of predefined token modifiers. This set is not fixed
 /// and clients can specify additional token types via the
 /// corresponding client capabilities.
 ///
 /// @since 3.16.0
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
-pub struct SemanticTokenModifier(Cow<'static, str>);
+#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize, From)]
+pub struct SemanticTokenModifier(#[from(forward)] Cow<'static, str>);
 
 impl SemanticTokenModifier {
     pub const DECLARATION: SemanticTokenModifier = SemanticTokenModifier::new("declaration");
@@ -92,20 +81,8 @@ impl SemanticTokenModifier {
     }
 }
 
-impl From<String> for SemanticTokenModifier {
-    fn from(from: String) -> Self {
-        SemanticTokenModifier(Cow::from(from))
-    }
-}
-
-impl From<&'static str> for SemanticTokenModifier {
-    fn from(from: &'static str) -> Self {
-        SemanticTokenModifier::new(from)
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize)]
-pub struct TokenFormat(Cow<'static, str>);
+#[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Clone, Deserialize, Serialize, From)]
+pub struct TokenFormat(#[from(forward)] Cow<'static, str>);
 
 impl TokenFormat {
     pub const RELATIVE: TokenFormat = TokenFormat::new("relative");
@@ -116,18 +93,6 @@ impl TokenFormat {
 
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-}
-
-impl From<String> for TokenFormat {
-    fn from(from: String) -> Self {
-        TokenFormat(Cow::from(from))
-    }
-}
-
-impl From<&'static str> for TokenFormat {
-    fn from(from: &'static str) -> Self {
-        TokenFormat::new(from)
     }
 }
 
@@ -260,24 +225,12 @@ pub struct SemanticTokensPartialResult {
     pub data: Vec<SemanticToken>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum SemanticTokensResult {
     Tokens(SemanticTokens),
     Partial(SemanticTokensPartialResult),
-}
-
-impl From<SemanticTokens> for SemanticTokensResult {
-    fn from(from: SemanticTokens) -> Self {
-        SemanticTokensResult::Tokens(from)
-    }
-}
-
-impl From<SemanticTokensPartialResult> for SemanticTokensResult {
-    fn from(from: SemanticTokensPartialResult) -> Self {
-        SemanticTokensResult::Partial(from)
-    }
 }
 
 /// @since 3.16.0
@@ -296,25 +249,13 @@ pub struct SemanticTokensEdit {
     pub data: Option<Vec<SemanticToken>>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum SemanticTokensFullDeltaResult {
     Tokens(SemanticTokens),
     TokensDelta(SemanticTokensDelta),
     PartialTokensDelta { edits: Vec<SemanticTokensEdit> },
-}
-
-impl From<SemanticTokens> for SemanticTokensFullDeltaResult {
-    fn from(from: SemanticTokens) -> Self {
-        SemanticTokensFullDeltaResult::Tokens(from)
-    }
-}
-
-impl From<SemanticTokensDelta> for SemanticTokensFullDeltaResult {
-    fn from(from: SemanticTokensDelta) -> Self {
-        SemanticTokensFullDeltaResult::TokensDelta(from)
-    }
 }
 
 /// @since 3.16.0
@@ -448,24 +389,12 @@ pub struct SemanticTokensRegistrationOptions {
     pub static_registration_options: StaticRegistrationOptions,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum SemanticTokensServerCapabilities {
     SemanticTokensOptions(SemanticTokensOptions),
     SemanticTokensRegistrationOptions(SemanticTokensRegistrationOptions),
-}
-
-impl From<SemanticTokensOptions> for SemanticTokensServerCapabilities {
-    fn from(from: SemanticTokensOptions) -> Self {
-        SemanticTokensServerCapabilities::SemanticTokensOptions(from)
-    }
-}
-
-impl From<SemanticTokensRegistrationOptions> for SemanticTokensServerCapabilities {
-    fn from(from: SemanticTokensRegistrationOptions) -> Self {
-        SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(from)
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
@@ -527,24 +456,12 @@ pub struct SemanticTokensRangeParams {
     pub range: Range,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, From)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum SemanticTokensRangeResult {
     Tokens(SemanticTokens),
     Partial(SemanticTokensPartialResult),
-}
-
-impl From<SemanticTokens> for SemanticTokensRangeResult {
-    fn from(tokens: SemanticTokens) -> Self {
-        SemanticTokensRangeResult::Tokens(tokens)
-    }
-}
-
-impl From<SemanticTokensPartialResult> for SemanticTokensRangeResult {
-    fn from(partial: SemanticTokensPartialResult) -> Self {
-        SemanticTokensRangeResult::Partial(partial)
-    }
 }
 
 #[cfg(test)]

--- a/src/type_hierarchy.rs
+++ b/src/type_hierarchy.rs
@@ -1,7 +1,7 @@
 use crate::{
     DynamicRegistrationClientCapabilities, LSPAny, PartialResultParams, Range,
     StaticRegistrationOptions, SymbolKind, SymbolTag, TextDocumentPositionParams,
-    TextDocumentRegistrationOptions, Url, WorkDoneProgressOptions, WorkDoneProgressParams,
+    TextDocumentRegistrationOptions, Uri, WorkDoneProgressOptions, WorkDoneProgressParams,
 };
 
 use serde::{Deserialize, Serialize};
@@ -70,7 +70,7 @@ pub struct TypeHierarchyItem {
     pub detail: Option<String>,
 
     /// The resource identifier of this item.
-    pub uri: Url,
+    pub uri: Uri,
 
     /// The range enclosing this symbol not including leading/trailing whitespace
     /// but everything else, e.g. comments and code.

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,0 +1,80 @@
+use std::{hash::Hash, ops::Deref, str::FromStr};
+
+use serde::{de::Error, Deserialize, Serialize};
+
+/// Newtype struct around `fluent_uri::Uri<String>` with serialization implementations that use `as_str()` and 'from_str()' respectively.
+#[derive(Debug, Clone)]
+pub struct Uri(fluent_uri::Uri<String>);
+
+impl Serialize for Uri {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_str().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Uri {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        fluent_uri::Uri::<String>::parse_from(string)
+            .map(Uri)
+            .map_err(|(_, error)| Error::custom(error.to_string()))
+    }
+}
+
+impl Ord for Uri {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for Uri {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl FromStr for Uri {
+    type Err = fluent_uri::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TOUCH-UP:
+        // Use upstream `FromStr` implementation if and when
+        // https://github.com/yescallop/fluent-uri-rs/pull/10
+        // gets merged.
+        // fluent_uri::Uri::from_str(s).map(Self)
+        fluent_uri::Uri::parse(s).map(|uri| Self(uri.to_owned()))
+    }
+}
+
+impl Deref for Uri {
+    type Target = fluent_uri::Uri<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/*
+    TOUCH-UP: `PartialEq`, `Eq` and `Hash` could all be derived
+    if and when the respective implementations get merged upstream:
+    https://github.com/yescallop/fluent-uri-rs/pull/9
+*/
+impl PartialEq for Uri {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for Uri {}
+
+impl Hash for Uri {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
+    }
+}

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,9 +1,9 @@
-use std::{hash::Hash, ops::Deref, str::FromStr};
+use std::{hash::Hash, str::FromStr};
 
 use serde::{de::Error, Deserialize, Serialize};
 
 /// Newtype struct around `fluent_uri::Uri<String>` with serialization implementations that use `as_str()` and 'from_str()' respectively.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, derive_more::Deref)]
 pub struct Uri(fluent_uri::Uri<String>);
 
 impl Serialize for Uri {
@@ -49,14 +49,6 @@ impl FromStr for Uri {
         // gets merged.
         // fluent_uri::Uri::from_str(s).map(Self)
         fluent_uri::Uri::parse(s).map(|uri| Self(uri.to_owned()))
-    }
-}
-
-impl Deref for Uri {
-    type Target = fluent_uri::Uri<String>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,9 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use serde_json::Value;
 
-use url::Url;
-
-use crate::Range;
+use crate::{Range, Uri};
 
 #[derive(Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -139,7 +137,7 @@ pub struct ShowDocumentClientCapabilities {
 #[serde(rename_all = "camelCase")]
 pub struct ShowDocumentParams {
     /// The document uri to show.
-    pub uri: Url,
+    pub uri: Uri,
 
     /// Indicates to show the resource in an external program.
     /// To show for example `https://code.visualstudio.com/`

--- a/src/workspace_diagnostic.rs
+++ b/src/workspace_diagnostic.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::{
-    FullDocumentDiagnosticReport, PartialResultParams, UnchangedDocumentDiagnosticReport,
+    FullDocumentDiagnosticReport, PartialResultParams, UnchangedDocumentDiagnosticReport, Uri,
     WorkDoneProgressParams,
 };
 
@@ -29,7 +28,7 @@ pub struct DiagnosticWorkspaceClientCapabilities {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct PreviousResultId {
     /// The URI for which the client knows a result ID.
-    pub uri: Url,
+    pub uri: Uri,
 
     /// The value of the previous result ID.
     pub value: String,
@@ -62,7 +61,7 @@ pub struct WorkspaceDiagnosticParams {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceFullDocumentDiagnosticReport {
     /// The URI for which diagnostic information is reported.
-    pub uri: Url,
+    pub uri: Uri,
 
     /// The version number for which the diagnostics are reported.
     ///
@@ -80,7 +79,7 @@ pub struct WorkspaceFullDocumentDiagnosticReport {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceUnchangedDocumentDiagnosticReport {
     /// The URI for which diagnostic information is reported.
-    pub uri: Url,
+    pub uri: Uri,
 
     /// The version number for which the diagnostics are reported.
     ///

--- a/src/workspace_diagnostic.rs
+++ b/src/workspace_diagnostic.rs
@@ -93,23 +93,11 @@ pub struct WorkspaceUnchangedDocumentDiagnosticReport {
 /// A workspace diagnostic document report.
 ///
 /// @since 3.17.0
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, derive_more::From)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum WorkspaceDocumentDiagnosticReport {
     Full(WorkspaceFullDocumentDiagnosticReport),
     Unchanged(WorkspaceUnchangedDocumentDiagnosticReport),
-}
-
-impl From<WorkspaceFullDocumentDiagnosticReport> for WorkspaceDocumentDiagnosticReport {
-    fn from(from: WorkspaceFullDocumentDiagnosticReport) -> Self {
-        WorkspaceDocumentDiagnosticReport::Full(from)
-    }
-}
-
-impl From<WorkspaceUnchangedDocumentDiagnosticReport> for WorkspaceDocumentDiagnosticReport {
-    fn from(from: WorkspaceUnchangedDocumentDiagnosticReport) -> Self {
-        WorkspaceDocumentDiagnosticReport::Unchanged(from)
-    }
 }
 
 /// A workspace diagnostic report.
@@ -128,21 +116,9 @@ pub struct WorkspaceDiagnosticReportPartialResult {
     pub items: Vec<WorkspaceDocumentDiagnosticReport>,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone, derive_more::From)]
 #[serde(untagged)]
 pub enum WorkspaceDiagnosticReportResult {
     Report(WorkspaceDiagnosticReport),
     Partial(WorkspaceDiagnosticReportPartialResult),
-}
-
-impl From<WorkspaceDiagnosticReport> for WorkspaceDiagnosticReportResult {
-    fn from(from: WorkspaceDiagnosticReport) -> Self {
-        WorkspaceDiagnosticReportResult::Report(from)
-    }
-}
-
-impl From<WorkspaceDiagnosticReportPartialResult> for WorkspaceDiagnosticReportResult {
-    fn from(from: WorkspaceDiagnosticReportPartialResult) -> Self {
-        WorkspaceDiagnosticReportResult::Partial(from)
-    }
 }

--- a/src/workspace_folders.rs
+++ b/src/workspace_folders.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
-use url::Url;
 
-use crate::OneOf;
+use crate::{OneOf, Uri};
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,7 +24,7 @@ pub struct WorkspaceFoldersServerCapabilities {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceFolder {
     /// The associated URI for this workspace folder.
-    pub uri: Url,
+    pub uri: Uri,
     /// The name of the workspace folder. Defaults to the uri's basename.
     pub name: String,
 }

--- a/src/workspace_symbols.rs
+++ b/src/workspace_symbols.rs
@@ -1,6 +1,6 @@
 use crate::{
     LSPAny, Location, OneOf, PartialResultParams, SymbolInformation, SymbolKind,
-    SymbolKindCapability, SymbolTag, TagSupport, Url, WorkDoneProgressParams,
+    SymbolKindCapability, SymbolTag, TagSupport, Uri, WorkDoneProgressParams,
 };
 
 use serde::{Deserialize, Serialize};
@@ -94,7 +94,7 @@ pub struct WorkspaceSymbol {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct WorkspaceLocation {
-    pub uri: Url,
+    pub uri: Uri,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This PR simply replaces all manual implementation of `Deref` and `From` with the derive_more::{From, Deref}` attribute macros.

The purpose is not to say that this should be done, but it's more so a presentation on how it would look in practice. E.g. making it possibly easier to decide on whether a `44 insertions(+), 497 deletions(-)` commit outweighs the con of introducing one more dependency. (All sub-dependencies are already used by `serde`.) I would be perfectly understanding if this PR gets rejected 😊