### PR TITLE
Fixed incorrect result type for InlineValueRequest

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -860,7 +860,7 @@ pub enum InlineValueRequest {}
 
 impl Request for InlineValueRequest {
     type Params = InlineValueParams;
-    type Result = Option<InlineValue>;
+    type Result = Option<Vec<InlineValue>>;
     const METHOD: &'static str = "textDocument/inlineValue";
 }
 


### PR DESCRIPTION
The specification has InlineValue[] | null i.e. Option<Vec<InlineValue>>  (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlineValue). We have InlineValue | null i.e. Option<InlineValue>.