### PR TITLE
fix: Add deprecation note for `rootUri`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1076,9 +1076,8 @@ pub struct InitializeParams {
     /// The rootUri of the workspace. Is null if no
     /// folder is open. If both `rootPath` and `rootUri` are set
     /// `rootUri` wins.
-    ///
-    /// Deprecated in favour of `workspaceFolders`
     #[serde(default)]
+    #[deprecated(note = "Use `workspace_folders` instead when possible")]
     pub root_uri: Option<Url>,
 
     /// User provided initialization options.


### PR DESCRIPTION
Marks `root_uri` as deprecated. Closes #247