### PR TITLE
Derive `Hash` for `Location` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ pub type LSPArray = Vec<serde_json::Value>;
 
 /// Position in a text document expressed as zero-based line and character offset.
 /// A position is between two characters like an 'insert' cursor in a editor.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default, Deserialize, Serialize, Hash)]
 pub struct Position {
     /// Line position in a document (zero-based).
     pub line: u32,
@@ -258,7 +258,7 @@ impl Position {
 
 /// A range in a text document expressed as (zero-based) start and end positions.
 /// A range is comparable to a selection in an editor. Therefore the end position is exclusive.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Deserialize, Serialize, Hash)]
 pub struct Range {
     /// The range's start position.
     pub start: Position,
@@ -273,7 +273,7 @@ impl Range {
 }
 
 /// Represents a location inside a resource, such as a line inside a text file.
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, Hash)]
 pub struct Location {
     pub uri: Url,
     pub range: Range,


### PR DESCRIPTION
First of all thanks so much for this project!

As part of some work in [asm-lsp](https://github.com/bergercookie/asm-lsp), I found it would be helpful if the `Hash` trait was derived on the `Location` struct, which I've done in this PR.

I looked through some of the other types defined in this project and saw that some could have `Hash` derived, but others could not as they contain a field of type `serde_json::Value`, which does not implement `Hash`. Is there any downside to deriving this trait when possible? I'd be happy to go through and add `Hash` derives as allowed on all structs in the crate if that would be helpful :)