### PR TITLE
Fix `WorkspaceClientCapabilities` to match LSP specification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1360,7 +1360,7 @@ pub struct WorkspaceClientCapabilities {
     /// Client workspace capabilities specific to diagnostics.
     /// since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub diagnostic: Option<DiagnosticWorkspaceClientCapabilities>,
+    pub diagnostics: Option<DiagnosticWorkspaceClientCapabilities>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]


### PR DESCRIPTION
The `diagnostic` field on `WorkspaceClientCapabilities` is actually supposed to be called `diagnostics`. This can be confirmed in the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities).

<img width="468" alt="Screenshot 2024-04-16 at 6 41 18 PM" src="https://github.com/gluon-lang/lsp-types/assets/19577865/8ff6747f-6d85-45b5-b8bf-2343d95b0826">

A consequence of this mis-naming is that `DiagnosticWorkspaceClientCapabilities` are never de-serialized, and `diagnostic` will always be `None`. That's why it needs to be changed to `diagnostics`.